### PR TITLE
Added operation to add Border to elements that don't have them

### DIFF
--- a/src/Design.cs
+++ b/src/Design.cs
@@ -28,6 +28,8 @@ public class Design
 
     private readonly List<Property> _designableProperties;
 
+    private List<Property> _borderProperties;
+
     private readonly Logger logger = LogManager.GetCurrentClassLogger();
 
     public Property GetDesignableProperty(string propertyName)
@@ -135,7 +137,14 @@ public class Design
     /// </summary>
     public IEnumerable<Property> GetDesignableProperties()
     {
-        return _designableProperties;
+        if(_borderProperties != null)
+        {
+            foreach(var property in _borderProperties)
+                yield return property;
+        }
+
+        foreach(var property in _designableProperties)
+            yield return property;
     }
 
     protected virtual IEnumerable<Property> LoadDesignableProperties()
@@ -166,9 +175,7 @@ public class Design
         // Border properties - Most views dont have a border so Border is
         if(View.Border != null)
         {
-            yield return CreateSubProperty(nameof(Border.BorderStyle),nameof(View.Border),View.Border);
-            yield return CreateSubProperty(nameof(Border.BorderBrush),nameof(View.Border),View.Border);
-            yield return CreateSubProperty(nameof(Border.Effect3D),nameof(View.Border),View.Border);            
+            LoadBorderProperties();
         }
         
         yield return CreateProperty(nameof(View.TextAlignment));
@@ -253,6 +260,26 @@ public class Design
         }
     }
 
+
+    internal void LoadBorderProperties()
+    {
+        _borderProperties = new List<Property>();
+
+        _borderProperties.AddRange(
+            new[]
+            {
+                CreateSubProperty(nameof(Border.BorderStyle), nameof(View.Border), View.Border),
+                CreateSubProperty(nameof(Border.BorderBrush), nameof(View.Border), View.Border),
+                CreateSubProperty(nameof(Border.Effect3D), nameof(View.Border), View.Border),
+            });
+            
+    }
+    internal void ClearBorderProperties()
+    {
+        _borderProperties.Clear();
+    }
+
+
     private Property CreateSubProperty(string name, string subObjectName, object subObject)
     {
         return new Property(this,subObject.GetType().GetProperty(name)        
@@ -287,6 +314,11 @@ public class Design
             yield return new AddTabOperation(this);
             yield return new RemoveTabOperation(this);
             yield return new RenameTabOperation(this);
+        }
+
+        if (View.Border == null)
+        {
+            yield return new AddBorderOperation(this);
         }
 
     }

--- a/src/Operations/AddBorderOperation.cs
+++ b/src/Operations/AddBorderOperation.cs
@@ -1,0 +1,41 @@
+﻿using Terminal.Gui;
+
+namespace TerminalGuiDesigner.Operations;
+
+public class AddBorderOperation : Operation
+{
+    private Border? _border;
+
+    public Design Design { get; }
+
+    public AddBorderOperation(Design design)
+    {
+        Design = design;
+        
+        if(Design.View.Border != null)
+            IsImpossible = true;
+    }
+
+
+    public override void Do()
+    {
+        Design.View.Border = _border = new Border
+        {
+            Child = Design.View,
+            BorderStyle = BorderStyle.Single,
+        };
+
+        Design.LoadBorderProperties();
+    }
+
+    public override void Redo()
+    {
+        Design.View.Border = _border;
+    }
+
+    public override void Undo()
+    {
+        Design.View.Border = null;
+        Design.ClearBorderProperties();
+    }
+}

--- a/src/Operations/AddTabOperation.cs
+++ b/src/Operations/AddTabOperation.cs
@@ -3,7 +3,6 @@ using TerminalGuiDesigner.UI.Windows;
 using static Terminal.Gui.TabView;
 
 namespace TerminalGuiDesigner.Operations;
-
 public class AddTabOperation : Operation
 {
     private Tab? _tab;

--- a/src/ToCode/DesignToCode.cs
+++ b/src/ToCode/DesignToCode.cs
@@ -17,6 +17,10 @@ internal class DesignToCode : ToCodeBase
 
         AddFieldToClass(args, Design);
         AddConstructorCall(args, Design);
+    
+        // Add border if we have one
+        if(Design.View.Border != null)
+            AddBorderConstruct(args, Design);
 
         foreach (var prop in Design.GetDesignableProperties())
         {
@@ -42,5 +46,13 @@ internal class DesignToCode : ToCodeBase
 
         // call this.Add(someView)
         AddAddToViewStatement(args, Design, parentView);
+    }
+
+    private void AddBorderConstruct(CodeDomArgs args, Design design)
+    {
+        AddConstructorCall($"{design.FieldName}.{nameof(View.Border)}", typeof(Border), args);
+        AddPropertyAssignment(args, 
+            $"{design.FieldName}.{nameof(View.Border)}.{nameof(Border.Child)}",
+            new CodeFieldReferenceExpression(new CodeThisReferenceExpression(), design.FieldName));
     }
 }


### PR DESCRIPTION
TODO:
It would be nicer if the border properties were auto displayed and the `View.Border` automatically created when the properties are changed rather than needing an explicit operation

Also needs tests