### PR TITLE
Fixed #60 by calling all constructors up front in InitializeComponent

### DIFF
--- a/src/ToCode/DesignToCode.cs
+++ b/src/ToCode/DesignToCode.cs
@@ -15,7 +15,8 @@ internal class DesignToCode : ToCodeBase
     internal void ToCode(CodeDomArgs args, CodeExpression parentView)
     {
         AddFieldToClass(args, Design);
-        AddConstructorCall(args, Design);
+        var constructorCall = GetConstructorCall($"this.{Design.FieldName}",Design.View.GetType());
+        args.InitMethod.Statements.Insert(0, constructorCall);
 
         foreach (var prop in Design.GetDesignableProperties())
         {

--- a/src/ToCode/ToCodeBase.cs
+++ b/src/ToCode/ToCodeBase.cs
@@ -50,6 +50,11 @@ public abstract class ToCodeBase
     }
     protected void AddConstructorCall(CodeDomArgs args, string fullySpecifiedFieldName,Type typeToConstruct, params CodeExpression[] parameters)
     {
+        var constructAssign = GetConstructorCall(fullySpecifiedFieldName,typeToConstruct,parameters);
+        args.InitMethod.Statements.Add(constructAssign);
+    }
+    protected CodeAssignStatement GetConstructorCall(string fullySpecifiedFieldName, Type typeToConstruct, params CodeExpression[] parameters)
+    {
         // Construct it
         var constructLhs = new CodeFieldReferenceExpression();
         constructLhs.FieldName = fullySpecifiedFieldName;
@@ -57,9 +62,9 @@ public abstract class ToCodeBase
         var constructAssign = new CodeAssignStatement();
         constructAssign.Left = constructLhs;
         constructAssign.Right = constructRhs;
-        args.InitMethod.Statements.Add(constructAssign);
-    }
 
+        return constructAssign;
+    }
 
     /// <summary>
     /// Adds a line "this.someField.Text = "Heya"


### PR DESCRIPTION
This PR changes the order of statements output by DesignToCode.  ConstructorCalls (e.g. `this.label1 = new Terminal.Gui.Label();`) now all happen first thing upon entering `InitializeComponent` instead of happening in the same place as property assignment.


For example:
```csharp
private void InitializeComponent() {
            this.label1 = new Terminal.Gui.Label();
            this.btn = new Terminal.Gui.Button();
[...]
```

This avoids us having to worry about computing any kind of dependency based output order since instances will all be allocated before we start creating dependencies in the code (e.g. with PosRelative).