### PR TITLE
Fix Add/Paste not selecting newly created views in some situations

### DIFF
--- a/src/Operations/AddViewOperation.cs
+++ b/src/Operations/AddViewOperation.cs
@@ -44,8 +44,9 @@ public class AddViewOperation : Operation
         // user cancelled picking a type
         if(add == null || string.IsNullOrWhiteSpace(fieldName))
             return false;
-        
-        add.Data = to.CreateSubControlDesign(sourceCode,fieldName, add);
+
+        Design design;
+        add.Data = design = to.CreateSubControlDesign(sourceCode,fieldName, add);
 
         var v = GetViewToAddTo();
         v.Add(add);
@@ -53,6 +54,7 @@ public class AddViewOperation : Operation
         if(Application.Driver != null){
             add.SetFocus();
         }
+        SelectionManager.Instance.ForceSetSelection(design);
 
         v.SetNeedsDisplay();
         return true;

--- a/src/Operations/PasteOperation.cs
+++ b/src/Operations/PasteOperation.cs
@@ -40,7 +40,7 @@ public class PasteOperation : Operation
 
         MigratePosRelatives();
 
-        SelectionManager.Instance.SetSelection(_clones.Values.ToArray());
+        SelectionManager.Instance.ForceSetSelection(_clones.Values.ToArray());
         return didAny;
     }
 

--- a/src/SelectionManager.cs
+++ b/src/SelectionManager.cs
@@ -55,6 +55,7 @@ public class SelectionManager
         }
     }
 
+
     public static SelectionManager Instance = new();
     private ColorScheme selectedScheme;
 
@@ -67,13 +68,31 @@ public class SelectionManager
         return null;
     }
 
+    /// <summary>
+    /// Changes the selection without respecting <see cref="LockSelection"/>
+    /// </summary>
+    /// <param name="designs"></param>
+    public void ForceSetSelection(params Design[] designs)
+    {
+        SetSelection(false,designs);
+    }
+
+    /// <summary>
+    /// Sets the current <see cref="Selected"/> <see cref="Design"/> collection to <paramref name="designs"/>.
+    /// Does nothing if <see cref="LockSelection"/> is true.
+    /// </summary>
+    /// <param name="designs"></param>
     public void SetSelection(params Design[] designs)
     {
-        if (LockSelection)
+        SetSelection(true, designs);
+    }
+    private void SetSelection(bool respectLock, Design[] designs)
+    {
+        if (LockSelection && respectLock)
             return;
 
         // reset anything that was previously selected
-        Clear();
+        Clear(respectLock);
 
         // create a new selection based on these
         selection = new List<Design>(designs.Distinct());
@@ -101,9 +120,9 @@ public class SelectionManager
         }
     }
 
-    public void Clear()
+    public void Clear(bool respectLock = true)
     {
-        if (LockSelection)
+        if (LockSelection && respectLock)
             return;
 
         selection.Clear();

--- a/src/UI/Editor.cs
+++ b/src/UI/Editor.cs
@@ -272,12 +272,8 @@ Ctrl+Q - Quit
         _menuOpen = true;
         SelectionManager.Instance.LockSelection = true;
         menu.Show();
-        menu.MenuBar.MenuClosing += (m) =>
+        menu.MenuBar.MenuAllClosed += () =>
         {
-            // we only care about the root menu being closed
-            if (m.IsSubMenu)
-                return;
-
             _menuOpen = false;
             SelectionManager.Instance.LockSelection = false;
         };


### PR DESCRIPTION
`LockSelection` prevents unwanted selection changes while running `Operation`, especially via context menu where focus leaves/returns to main designer window.  However some operations actively want to 'force' change the selection regardless.  

This PR adds a new method `ForceSetSelection` to `SelectionManager` and uses it in `AddViewOperation` and `PasteOperation`.  This gives a more streamlined user experience.

**Before**
![bad gif](https://user-images.githubusercontent.com/31306100/185047148-fe65baac-3138-4bdc-83ca-4a886f949fd2.gif)
_The right hand view wrongly remains selected after pasting_

**After**
![good gif](https://user-images.githubusercontent.com/31306100/185047477-9f02e26a-afbd-4f6b-85e8-f198315e378c.gif)
_The newly pasted controls are selected_
