### PR TITLE
Fix SelectAll key combination not working

### DIFF
--- a/src/UI/Editor.cs
+++ b/src/UI/Editor.cs
@@ -580,7 +580,7 @@ Ctrl+Q - Quit
             .Where(d=>!d.IsRoot)
             .ToArray();
 
-        SelectionManager.Instance.SetSelection(everyone);
+        SelectionManager.Instance.ForceSetSelection(everyone);
     }
 
     private void Paste()


### PR DESCRIPTION
A while back `SelectionManager.Instance.LockSelection` was introduced to prevent keybound operations accidentally changing the selected controls.   This change meant any deliberate focus changes had to be changed to use `ForceSelection`.  

It seems SelectAll was not changed yet to force this.  This PR fixes that.