### PR TITLE
Pos anchor end

### DIFF
--- a/src/PosExtensions.cs
+++ b/src/PosExtensions.cs
@@ -353,6 +353,13 @@ public static class PosExtensions
                     return $"Pos.Center() - {Math.Abs(offset)}";
                 return $"Pos.Center()";
 
+            case PosType.AnchorEnd:
+                if (offset > 0)
+                    return $"Pos.AnchorEnd({(int)val}) + {offset}";
+                if (offset < 0)
+                    return $"Pos.AnchorEnd({(int)val}) - {Math.Abs(offset)}";
+                return $"Pos.AnchorEnd({(int)val})";
+
             default: throw new ArgumentOutOfRangeException(nameof(type));
         }
     }

--- a/src/PosType.cs
+++ b/src/PosType.cs
@@ -6,5 +6,6 @@ public enum PosType
     Anchor,
     Percent,
     Relative,
-    Center
+    Center,
+    AnchorEnd
 }

--- a/src/PosType.cs
+++ b/src/PosType.cs
@@ -3,9 +3,8 @@ namespace TerminalGuiDesigner;
 public enum PosType
 {
     Absolute,
-    Anchor,
+    AnchorEnd,
     Percent,
     Relative,
-    Center,
-    AnchorEnd
+    Center,    
 }

--- a/src/UI/Windows/PosEditor.Designer.cs
+++ b/src/UI/Windows/PosEditor.Designer.cs
@@ -63,8 +63,8 @@ namespace TerminalGuiDesigner.UI.Windows {
             this.Border.DrawMarginFrame = true;
             this.TextAlignment = Terminal.Gui.TextAlignment.Left;
             this.Title = "";
-            this.rgPosType.Width = 11;
-            this.rgPosType.Height = 4;
+            this.rgPosType.Width = 12;
+            this.rgPosType.Height = 5;
             this.rgPosType.X = 1;
             this.rgPosType.Y = 1;
             this.rgPosType.Data = "rgPosType";
@@ -74,7 +74,8 @@ namespace TerminalGuiDesigner.UI.Windows {
                     "Absolute",
                     "Percent",
                     "Relative",
-                    "Center"};
+                    "Center",
+                    "AnchorEnd"};
             this.Add(this.rgPosType);
             this.lineview1.Width = 1;
             this.lineview1.Height = 4;

--- a/src/UI/Windows/PosEditor.cs
+++ b/src/UI/Windows/PosEditor.cs
@@ -189,6 +189,16 @@ namespace TerminalGuiDesigner.UI.Windows
 
         private void BtnOk_Clicked()
         {
+            if(GetPosType() == PosType.AnchorEnd && GetValue(out var value) && value <=0)
+            {
+                var confirm = MessageBox.Query("AnchorAt with no Margin", "Using AnchorEnd without a Margin will result in a Point outside of parent bounds.  Are you sure?", "Yes", "No");
+                
+                if (confirm == 1)
+                {
+                    return;
+                }   
+            }
+
             Cancelled = !BuildPos(out var result);
             Result = result;
             Application.RequestStop();

--- a/src/UI/Windows/PosEditor.cs
+++ b/src/UI/Windows/PosEditor.cs
@@ -66,8 +66,10 @@ namespace TerminalGuiDesigner.UI.Windows
                         ddSide.SelectedItem = (int)side;
                         break;
                     case PosType.Center:
-                        rgPosType.SelectedItem = 3;
-                        
+                        rgPosType.SelectedItem = 3;                        
+                        break;
+                    case PosType.AnchorEnd:
+                        rgPosType.SelectedItem = 4;
                         break;
                 }
 
@@ -102,7 +104,6 @@ namespace TerminalGuiDesigner.UI.Windows
             
             switch(GetPosType())
             {
-                case PosType.Anchor:
                 case PosType.Percent:
                     lblRelativeTo.Visible = false;
                     ddRelativeTo.Visible = false;
@@ -138,6 +139,7 @@ namespace TerminalGuiDesigner.UI.Windows
                     SetNeedsDisplay();
                     break;
                 case PosType.Absolute:
+                case PosType.AnchorEnd:
                     ddRelativeTo.Visible = false;
                     lblRelativeTo.Visible = false;
                     lblSide.Visible = false;
@@ -207,7 +209,8 @@ namespace TerminalGuiDesigner.UI.Windows
                     return BuildPosPercent(out result);
                 case PosType.Center:
                     return BuildPosCenter(out result);
-                case PosType.Anchor: throw new NotImplementedException();
+                case PosType.AnchorEnd:
+                    return BuildPosAnchorEnd(out result);
 
                 default: throw new ArgumentOutOfRangeException();
 
@@ -272,6 +275,18 @@ namespace TerminalGuiDesigner.UI.Windows
             if (GetValue(out int newPos))
             {
                 result = Pos.At(newPos);
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+
+        private bool BuildPosAnchorEnd(out Pos result)
+        {
+            if (GetValue(out int newPos))
+            {
+                result = Pos.AnchorEnd(newPos);
                 return true;
             }
 

--- a/tests/PosTests.cs
+++ b/tests/PosTests.cs
@@ -18,6 +18,7 @@ public class PosTests : Tests
         Assert.IsTrue(Pos.At(50).IsAbsolute());
         Assert.IsFalse(Pos.At(50).IsPercent());
         Assert.IsFalse(Pos.At(50).IsRelative(out _));
+        Assert.IsFalse(Pos.At(50).IsAnchorEnd(out _));
 
         Assert.IsTrue(Pos.At(50).IsAbsolute(out int size));
         Assert.AreEqual(50,size);
@@ -35,6 +36,7 @@ public class PosTests : Tests
         Assert.IsTrue(p.IsAbsolute());
         Assert.IsFalse(p.IsPercent());
         Assert.IsFalse(p.IsRelative(out _));
+        Assert.IsFalse(p.IsAnchorEnd(out _));
 
         Assert.IsTrue(p.IsAbsolute(out int size));
         Assert.AreEqual(50,size);
@@ -51,6 +53,7 @@ public class PosTests : Tests
         Assert.IsFalse(Pos.Percent(24).IsAbsolute());
         Assert.IsTrue(Pos.Percent(24).IsPercent());
         Assert.IsFalse(Pos.Percent(24).IsRelative(out _));
+        Assert.IsFalse(Pos.Percent(24).IsAnchorEnd(out _));
 
         Assert.IsTrue(Pos.Percent(24).IsPercent(out var size));
         Assert.AreEqual(24f,size);
@@ -71,6 +74,7 @@ public class PosTests : Tests
         Assert.IsFalse(Pos.Top(v).IsAbsolute());
         Assert.IsFalse(Pos.Top(v).IsPercent());
         Assert.IsTrue(Pos.Top(v).IsRelative(out _));
+        Assert.IsFalse(Pos.Top(v).IsAnchorEnd(out _));
 
         Assert.IsTrue(Pos.Top(v).IsRelative(new List<Design>{d},out var relativeTo, out var side));
         Assert.AreSame(d,relativeTo);
@@ -80,6 +84,54 @@ public class PosTests : Tests
         Assert.AreEqual(PosType.Relative,type);
         Assert.AreSame(d,relativeTo);
         Assert.AreEqual(Side.Top,side);
+    }
+
+    [Test]
+    public void TestIsAnchorEnd()
+    {
+        Assert.IsFalse(Pos.AnchorEnd().IsAbsolute());
+        Assert.IsFalse(Pos.AnchorEnd().IsPercent());
+        Assert.IsFalse(Pos.AnchorEnd().IsRelative(out _));
+        Assert.IsTrue(Pos.AnchorEnd().IsAnchorEnd(out _));
+
+        Assert.IsTrue(Pos.AnchorEnd().IsAnchorEnd(out var margin));
+        Assert.AreEqual(0, margin);
+
+        Assert.IsTrue(Pos.AnchorEnd().GetPosType(new List<Design>(), out var type, out var val, out var design, out var side, out var offset));
+        Assert.AreEqual(PosType.AnchorEnd, type);
+        Assert.AreEqual(0, val);
+        Assert.AreEqual(0, offset);
+    }
+    [Test]
+    public void TestIsAnchorEnd_WithMargin()
+    {
+        Assert.IsFalse(Pos.AnchorEnd(2).IsAbsolute());
+        Assert.IsFalse(Pos.AnchorEnd(2).IsPercent());
+        Assert.IsFalse(Pos.AnchorEnd(2).IsRelative(out _));
+        Assert.IsTrue(Pos.AnchorEnd(2).IsAnchorEnd(out _));
+
+        Assert.IsTrue(Pos.AnchorEnd(2).IsAnchorEnd(out var margin));
+        Assert.AreEqual(2, margin);
+
+        Assert.IsTrue(Pos.AnchorEnd(2).GetPosType(new List<Design>(), out var type, out var val, out var design, out var side, out var offset));
+        Assert.AreEqual(PosType.AnchorEnd, type);
+        Assert.AreEqual(2, val);
+        Assert.AreEqual(0, offset);
+    }
+
+    [Test]
+    public void TestIsAnchorEnd_WithOffset()
+    {
+        Assert.IsTrue((Pos.AnchorEnd(1) + 2).GetPosType(new List<Design>(), out var type, out var val, out var design, out var side, out var offset));
+        Assert.AreEqual(PosType.AnchorEnd, type);
+        Assert.AreEqual(1, val);
+        Assert.AreEqual(2, offset);
+
+
+        Assert.IsTrue((Pos.AnchorEnd(1) - 2).GetPosType(new List<Design>(), out type, out val, out design, out side, out offset));
+        Assert.AreEqual(PosType.AnchorEnd, type);
+        Assert.AreEqual(1, val);
+        Assert.AreEqual(-2, offset);
     }
 
     [Test]
@@ -242,6 +294,6 @@ public class PosTests : Tests
         Assert.AreEqual(PosType.Relative, backInType);
         Assert.AreEqual(offset, backInOffset);
         Assert.IsNotNull(backInRelativeTo);
-        Assert.IsInstanceOf<Label>(backInRelativeTo.View);
+        Assert.IsInstanceOf<Label>(backInRelativeTo?.View);
     }
 }

--- a/tests/PosTests.cs
+++ b/tests/PosTests.cs
@@ -296,4 +296,76 @@ public class PosTests : Tests
         Assert.IsNotNull(backInRelativeTo);
         Assert.IsInstanceOf<Label>(backInRelativeTo?.View);
     }
+
+    [Test]
+    public void TestRoundTrip_PosAnchorEnd()
+    {
+        var viewToCode = new ViewToCode();
+
+        var file = new FileInfo("TestRoundTrip_PosAnchorEnd.cs");
+        var designOut = viewToCode.GenerateNewView(file, "YourNamespace", typeof(Window), out var sourceCode);
+
+        designOut.View.Width = 100;
+        designOut.View.Height = 100;
+
+        var factory = new ViewFactory();
+        var lbl = factory.Create(typeof(Label));
+        lbl.X = Pos.AnchorEnd(1);
+        lbl.Y = Pos.AnchorEnd(4); // length of "Heya"
+
+        new AddViewOperation(sourceCode, lbl, designOut, "label1").Do();
+
+        viewToCode.GenerateDesignerCs(designOut, designOut.SourceCode, typeof(Window));
+
+        var codeToView = new CodeToView(sourceCode);
+        var designBackIn = codeToView.CreateInstance();
+
+        var lblIn = designBackIn.View.GetActualSubviews().OfType<Label>().Single();
+
+        lblIn.X.GetPosType(designBackIn.GetAllDesigns().ToList(), out var backInType, out var backInValue, out _, out _, out var backInOffset);
+        Assert.AreEqual(0, backInOffset);
+        Assert.AreEqual(PosType.AnchorEnd, backInType);
+        Assert.AreEqual(1, backInValue);
+
+        lblIn.Y.GetPosType(designBackIn.GetAllDesigns().ToList(), out backInType, out backInValue, out _, out _, out backInOffset);
+        Assert.AreEqual(0, backInOffset);
+        Assert.AreEqual(PosType.AnchorEnd, backInType);
+        Assert.AreEqual(4, backInValue);
+    }
+
+    [Test]
+    public void TestRoundTrip_PosAnchorEnd_WithOffset()
+    {
+        var viewToCode = new ViewToCode();
+
+        var file = new FileInfo("TestRoundTrip_PosAnchorEnd.cs");
+        var designOut = viewToCode.GenerateNewView(file, "YourNamespace", typeof(Window), out var sourceCode);
+
+        designOut.View.Width = 100;
+        designOut.View.Height = 100;
+
+        var factory = new ViewFactory();
+        var lbl = factory.Create(typeof(Label));
+        lbl.X = Pos.AnchorEnd(1) + 5;
+        lbl.Y = Pos.AnchorEnd(4) - 3; // length of "Heya"
+
+        new AddViewOperation(sourceCode, lbl, designOut, "label1").Do();
+
+        viewToCode.GenerateDesignerCs(designOut, designOut.SourceCode, typeof(Window));
+
+        var codeToView = new CodeToView(sourceCode);
+        var designBackIn = codeToView.CreateInstance();
+
+        var lblIn = designBackIn.View.GetActualSubviews().OfType<Label>().Single();
+
+        lblIn.X.GetPosType(designBackIn.GetAllDesigns().ToList(), out var backInType, out var backInValue, out _, out _, out var backInOffset);
+        Assert.AreEqual(5, backInOffset);
+        Assert.AreEqual(PosType.AnchorEnd, backInType);
+        Assert.AreEqual(1, backInValue);
+
+        lblIn.Y.GetPosType(designBackIn.GetAllDesigns().ToList(), out backInType, out backInValue, out _, out _, out backInOffset);
+        Assert.AreEqual(-3, backInOffset);
+        Assert.AreEqual(PosType.AnchorEnd, backInType);
+        Assert.AreEqual(4, backInValue);
+    }
 }


### PR DESCRIPTION
Adds support for AnchorEnd PosType:

Generate and runtime detection for the following static methods/private types:
```
this.label1.X = Pos.AnchorEnd(11);
this.label1.Y = Pos.AnchorEnd(1);
```

Also warns user if not specifying any value (or negative one) e.g. `Pos.AnchorEnd()` which results in view being offscreen

![image](https://user-images.githubusercontent.com/31306100/196376475-ea446c15-5ae2-40a2-9724-0478438ed19e.png)
