### PR TITLE
Tweak RadioGroup

### DIFF
--- a/src/Design.cs
+++ b/src/Design.cs
@@ -428,6 +428,7 @@ public class Design
         if (this.View is RadioGroup)
         {
             yield return this.CreateProperty(nameof(RadioGroup.RadioLabels));
+            yield return this.CreateProperty(nameof(RadioGroup.DisplayMode));
         }
     }
 

--- a/src/ViewFactory.cs
+++ b/src/ViewFactory.cs
@@ -199,7 +199,7 @@ public class ViewFactory
         var group = new RadioGroup
         {
             Width = 10,
-            Height = 5,
+            Height = 2,
         };
         group.RadioLabels = new ustring[] { "Option 1", "Option 2" };
 


### PR DESCRIPTION
So it turns out that RadioGroup already handles its own sizing with absolute relayout.  Partly the reason for this is because of its DisplayMode.  So I will close #145 with no action but this PR is nice anyway. 

It fixes the ViewFactory size created to match the number of placeholder labels and makes DisplayMode designable so user can have horizontal labels:

Fixes #145 

![image](https://user-images.githubusercontent.com/31306100/201530211-f3d2965a-3f41-4d84-8e76-d17c2e556546.png)