### PR TITLE
Fixes some issues with MenuBar

### DIFF
--- a/src/ToCode/MenuBarItemsToCode.cs
+++ b/src/ToCode/MenuBarItemsToCode.cs
@@ -99,12 +99,15 @@ public class MenuBarItemsToCode : ToCodeBase
                 this.AddPropertyAssignment(args, $"this.{subFieldName}.{nameof(MenuItem.Title)}", sub.Title);
                 this.AddPropertyAssignment(args, $"this.{subFieldName}.{nameof(MenuItem.Data)}", subFieldName);
 
-                this.AddPropertyAssignment(
+                if (sub.Shortcut != Key.Null)
+                {
+                    this.AddPropertyAssignment(
                     args,
                     $"this.{subFieldName}.{nameof(MenuItem.Shortcut)}",
                     new CodeCastExpression(
                         new CodeTypeReference(typeof(Key)),
                         new CodePrimitiveExpression((uint)sub.Shortcut)));
+                }
 
                 children.Add(subFieldName);
             }
@@ -129,8 +132,20 @@ public class MenuBarItemsToCode : ToCodeBase
 
     private string GetUniqueFieldName(CodeDomArgs args, MenuItem item)
     {
-        return args.GetUniqueFieldName(
-            item.Data as string ??
-            item.Title.ToString());
+        // if user has an explicit name they have set
+        if (item.Data is string s)
+        {
+            return args.GetUniqueFieldName(s);
+        }
+
+        var fname = args.GetUniqueFieldName(item.Title.ToString() + "MenuItem");
+
+        // ensure name is camel case since MenuItem are created as private fields
+        if (char.IsUpper(fname[0]))
+        {
+            return char.ToLower(fname[0]) + fname.Substring(1);
+        }
+
+        return fname;
     }
 }

--- a/src/ToCode/MenuBarItemsToCode.cs
+++ b/src/ToCode/MenuBarItemsToCode.cs
@@ -140,7 +140,12 @@ public class MenuBarItemsToCode : ToCodeBase
 
         var suffix = item is MenuBarItem ? "Menu" : "MenuItem";
 
-        var fname = args.GetUniqueFieldName(item.Title.ToString() + suffix);
+        // Remove underscores from title when generating field name because those indicate shortcut keys
+        // and are not rendered (user might not even be aware they are there).
+        var title = item.Title.ToString()?.Replace('_', ' ');
+
+        // Make sure name + suffix is unique and not null
+        var fname = args.GetUniqueFieldName(title + suffix);
 
         // ensure name is camel case since MenuItem are created as private fields
         if (char.IsUpper(fname[0]))

--- a/src/ToCode/MenuBarItemsToCode.cs
+++ b/src/ToCode/MenuBarItemsToCode.cs
@@ -138,7 +138,9 @@ public class MenuBarItemsToCode : ToCodeBase
             return args.GetUniqueFieldName(s);
         }
 
-        var fname = args.GetUniqueFieldName(item.Title.ToString() + "MenuItem");
+        var suffix = item is MenuBarItem ? "Menu" : "MenuItem";
+
+        var fname = args.GetUniqueFieldName(item.Title.ToString() + suffix);
 
         // ensure name is camel case since MenuItem are created as private fields
         if (char.IsUpper(fname[0]))

--- a/src/ViewExtensions.cs
+++ b/src/ViewExtensions.cs
@@ -376,7 +376,8 @@ public static class ViewExtensions
         // but order everything else top left to bottom right
         return views
             .OrderBy(v => v is MenuBar ? int.MaxValue : 0)
-            .ThenBy(v => v.Frame.Y).ThenBy(v => v.Frame.X);
+            .ThenBy(v => v.Frame.Y)
+            .ThenBy(v => v.Frame.X);
     }
 
     /// <summary>

--- a/src/ViewExtensions.cs
+++ b/src/ViewExtensions.cs
@@ -372,7 +372,11 @@ public static class ViewExtensions
     /// <returns>Collection ordered by screen position.</returns>
     public static IEnumerable<View> OrderViewsByScreenPosition(IEnumerable<View> views)
     {
-        return views.OrderBy(v => v.Frame.Y).ThenBy(v => v.Frame.X);
+        // always put MenuBar last so that it appears top in z order
+        // but order everything else top left to bottom right
+        return views
+            .OrderBy(v => v is MenuBar ? int.MaxValue : 0)
+            .ThenBy(v => v.Frame.Y).ThenBy(v => v.Frame.X);
     }
 
     /// <summary>

--- a/tests/Operations/AddMenuOperationTests.cs
+++ b/tests/Operations/AddMenuOperationTests.cs
@@ -1,6 +1,8 @@
 ﻿using NUnit.Framework;
 using System;
+using System.IO;
 using Terminal.Gui;
+using TerminalGuiDesigner;
 using TerminalGuiDesigner.Operations;
 
 namespace UnitTests.Operations;
@@ -78,6 +80,21 @@ internal class AddMenuOperationTests : Tests
         Assert.AreEqual(3, viewIn.Menus.Length);
         Assert.AreEqual("Fish", viewIn.Menus[1].Title.ToString());
         Assert.AreEqual("Fish2", viewIn.Menus[2].Title.ToString());
+
+        // Check that the .Designer.cs is producing sensible private field names
+        FileAssert.Exists(((Design)viewIn.Data).SourceCode.DesignerFile);
+        var code = File.ReadAllText(((Design)viewIn.Data).SourceCode.DesignerFile.FullName);
+
+        StringAssert.Contains("private Terminal.Gui.MenuBarItem _FileF9Menu;", code);
+        StringAssert.Contains("private Terminal.Gui.MenuBarItem fishMenu;", code);
+        StringAssert.Contains("private Terminal.Gui.MenuBarItem fishMenu2;", code);
+
+
+        StringAssert.Contains(
+            "private Terminal.Gui.MenuItem editMeMenuItem;",
+            code,
+            "Expected these to be created as template items under the new top level menus");
+        StringAssert.Contains("private Terminal.Gui.MenuItem editMe2MenuItem;", code);
     }
     [Test]
     public void TestAddingMenu_AtRoot_UnDo()

--- a/tests/Operations/AddMenuOperationTests.cs
+++ b/tests/Operations/AddMenuOperationTests.cs
@@ -87,14 +87,14 @@ internal class AddMenuOperationTests : Tests
 
         StringAssert.Contains("private Terminal.Gui.MenuBarItem _FileF9Menu;", code);
         StringAssert.Contains("private Terminal.Gui.MenuBarItem fishMenu;", code);
-        StringAssert.Contains("private Terminal.Gui.MenuBarItem fishMenu2;", code);
+        StringAssert.Contains("private Terminal.Gui.MenuBarItem fish2Menu;", code);
 
 
         StringAssert.Contains(
             "private Terminal.Gui.MenuItem editMeMenuItem;",
             code,
             "Expected these to be created as template items under the new top level menus");
-        StringAssert.Contains("private Terminal.Gui.MenuItem editMe2MenuItem;", code);
+        StringAssert.Contains("private Terminal.Gui.MenuItem editMeMenuItem2;", code);
     }
     [Test]
     public void TestAddingMenu_AtRoot_UnDo()

--- a/tests/Operations/AddMenuOperationTests.cs
+++ b/tests/Operations/AddMenuOperationTests.cs
@@ -85,7 +85,7 @@ internal class AddMenuOperationTests : Tests
         FileAssert.Exists(((Design)viewIn.Data).SourceCode.DesignerFile);
         var code = File.ReadAllText(((Design)viewIn.Data).SourceCode.DesignerFile.FullName);
 
-        StringAssert.Contains("private Terminal.Gui.MenuBarItem _FileF9Menu;", code);
+        StringAssert.Contains("private Terminal.Gui.MenuBarItem fileF9Menu;", code);
         StringAssert.Contains("private Terminal.Gui.MenuBarItem fishMenu;", code);
         StringAssert.Contains("private Terminal.Gui.MenuBarItem fish2Menu;", code);
 

--- a/tests/Operations/AddViewOperationTests.cs
+++ b/tests/Operations/AddViewOperationTests.cs
@@ -42,7 +42,9 @@ internal class AddViewOperationTests : Tests
     {
         int stackSize = 0;
         var factory = new ViewFactory();
-        var supportedViews = ViewFactory.GetSupportedViews().ToArray();
+        var supportedViews = ViewFactory.GetSupportedViews()
+            // Add MenuBar last so order is preserved in Assert check.
+            .OrderBy(t=>t == typeof(MenuBar) ? int.MaxValue : 0).ToArray();
 
         var windowIn = RoundTrip<Toplevel, Window>((d, v) =>
         {

--- a/tests/Tests.cs
+++ b/tests/Tests.cs
@@ -102,13 +102,6 @@ internal class Tests
         var codeToView = new CodeToView(designOut.SourceCode);
         var designBackIn = codeToView.CreateInstance();
 
-        // Cleanup temp files unless user is trying to debug failing unit tests
-        if (!Debugger.IsAttached)
-        {
-            codeToView.SourceFile.CsFile.Delete();
-            codeToView.SourceFile.DesignerFile.Delete();
-        }
-
         return designBackIn.View.GetActualSubviews().OfType<T2>().Where(v => v.Data is Design d && d.FieldName.Equals(fieldName)).Single();
     }
     /// <summary>


### PR DESCRIPTION
Fixes #153 - MenuBar appearing below other Views
Fixes #152 - Outputting code to set `Shortcut` on MenuItems when they are null (0)
Fixes #151 - Naming of menu items now matches WinForms

Previously a menu called "Delete Stuff" was called `DeleteStuff` now it is called `deleteStuffMenuItem` which is consistent with the way Winforms designer names stuff and I think makes it way easier for user to hook events in their `MyView.cs` file.

I've also removed the 'cleanup' code in testing helper method `RoundTrip<T1,T2>` so it never deletes code files.  That allows tests to look for bits of code in the c# outputted by designer if they want.