### PR TITLE
Improve private field name generation

### DIFF
--- a/src/Design.cs
+++ b/src/Design.cs
@@ -513,7 +513,7 @@ public class Design
 
         var allDesigns = root.GetAllDesigns();
 
-        var name = CodeDomArgs.MakeValidFieldName($"{viewType.Name.ToLower()}");
+        var name = CodeDomArgs.MakeValidFieldName($"{viewType.Name}");
         return name.MakeUnique(allDesigns.Select(d => d.FieldName));
     }
 

--- a/src/ToCode/MenuBarItemsToCode.cs
+++ b/src/ToCode/MenuBarItemsToCode.cs
@@ -147,12 +147,6 @@ public class MenuBarItemsToCode : ToCodeBase
         // Make sure name + suffix is unique and not null
         var fname = args.GetUniqueFieldName(title + suffix);
 
-        // ensure name is camel case since MenuItem are created as private fields
-        if (char.IsUpper(fname[0]))
-        {
-            return char.ToLower(fname[0]) + fname.Substring(1);
-        }
-
         return fname;
     }
 }

--- a/tests/ToCode/CodeDomArgsTests.cs
+++ b/tests/ToCode/CodeDomArgsTests.cs
@@ -22,6 +22,17 @@ namespace UnitTests.ToCode
         public void Test_MakeValidFieldName(string? input, string expectedOutput)
         {
             Assert.AreEqual(expectedOutput, CodeDomArgs.MakeValidFieldName(input));
+
+            // when public we should start with an upper case letter
+            Assert.IsTrue(char.IsUpper(CodeDomArgs.MakeValidFieldName(name: input, isPublic: true)[0]));
+
+            // when private we should start with an upper case letter
+            Assert.IsFalse(char.IsUpper(CodeDomArgs.MakeValidFieldName(name: input, isPublic: false)[0]));
+
+            Assert.AreEqual(
+                CodeDomArgs.MakeValidFieldName(input, true).Substring(1),
+                CodeDomArgs.MakeValidFieldName(input, false).Substring(1),
+                "Expected public/private to only differ on first letter caps");
         }
 
         [TestCaseSource("cases")]

--- a/tests/ToCode/CodeDomArgsTests.cs
+++ b/tests/ToCode/CodeDomArgsTests.cs
@@ -8,11 +8,14 @@ namespace UnitTests.ToCode
 
         public static object[] cases = new object[]{
             new object[]{"fff", "fff"},
-            new object[]{ "33Dalmations", "Dalmations"},
+            new object[]{ "33Dalmations", "dalmations"},
+            new object[]{ "Dalmations33", "dalmations33"},
             new object[]{ "", "blank" },
+            new object[]{ "bob is great", "bobIsGreat" },
             new object[]{ "\t", "blank" },
             new object?[]{ null, "blank" },
-            new object[]{ "test\r\nffish\r\n", "testffish" },
+            new object[]{ "test\r\nffish\r\n", "testFfish" },
+            new object[]{ "test\r\nffish\r\n", "testFfish" },
         };
 
         [TestCaseSource("cases")]


### PR DESCRIPTION
Update private variable naming to prefer camel case and capitalize after spaces / in Type names

Now generates names that fit with csharp style.  This improves on #154 and applies to new views too.

For example adding a `MenuBar` class will get an auto generated name `menuBar` (or `menuBar2` etc) instead of always being lower cased.

When field name is generated from a text string e.g. `Title` spaces are handled by bumping next char to capital:

```csharp
private Terminal.Gui.MenuBar menuBar;        
private Terminal.Gui.MenuBarItem testMenu;        
private Terminal.Gui.MenuItem doubleTestMenuItem;
```