### PR TITLE
Adds MoveColumnOperation

### DIFF
--- a/src/Design.cs
+++ b/src/Design.cs
@@ -4,6 +4,7 @@ using Terminal.Gui;
 using Terminal.Gui.Graphs;
 using Terminal.Gui.Trees;
 using TerminalGuiDesigner.Operations;
+using TerminalGuiDesigner.Operations.TableViewOperations;
 using TerminalGuiDesigner.ToCode;
 using static Terminal.Gui.TableView;
 using static Terminal.Gui.TabView;
@@ -381,6 +382,8 @@ public class Design
             {
                 yield return new RemoveColumnOperation(this, col);
                 yield return new RenameColumnOperation(this, col);
+                yield return new MoveColumnOperation(this, col, -1);
+                yield return new MoveColumnOperation(this, col, 1);
             }
         }
 

--- a/src/Design.cs
+++ b/src/Design.cs
@@ -360,9 +360,11 @@ public class Design
             DataColumn? col = null;
             if (!pos.IsEmpty)
             {
-                // TODO: Currently you have to right click in the row (body) of the table
-                // and cannot right click the headers themselves
-                var cell = tv.ScreenToCell(pos.X, pos.Y);
+                // See which column the right click lands.  If nowhere (but still within TableView) then it
+                // might be a click in the header (i.e. too high up to hit a cell).  So check with Y coordinate
+                // close to bottom of control see if that gives a non null result.
+                var cell = tv.ScreenToCell(pos.X, pos.Y) ?? tv.ScreenToCell(pos.X, tv.Frame.Bottom - 2);
+
                 if (cell != null)
                 {
                     col = tv.Table.Columns[cell.Value.X];

--- a/src/Operations/IOperation.cs
+++ b/src/Operations/IOperation.cs
@@ -12,6 +12,13 @@ public interface IOperation
     /// </summary>
     Guid UniqueIdentifier { get; }
 
+
+    /// <summary>
+    /// Gets the category to put this <see cref="Operation"/>
+    /// under in context menus.
+    /// </summary>
+    string Category { get; }
+
     /// <summary>
     /// Gets a value indicating whether the <see cref="IOperation"/> is in a valid
     /// state for execution.

--- a/src/Operations/Operation.cs
+++ b/src/Operations/Operation.cs
@@ -17,6 +17,9 @@ public abstract class Operation : IOperation
     public Guid UniqueIdentifier { get; } = Guid.NewGuid();
 
     /// <inheritdoc/>
+    public string Category { get; protected set; } = string.Empty;
+
+    /// <inheritdoc/>
     /// <remarks>Defaults to <see cref="GetOperationName"/>.</remarks>
     public override string ToString()
     {

--- a/src/Operations/TableViewOperations/AddColumnOperation.cs
+++ b/src/Operations/TableViewOperations/AddColumnOperation.cs
@@ -1,8 +1,9 @@
 ﻿using System.Data;
 using Terminal.Gui;
+using TerminalGuiDesigner;
 using TerminalGuiDesigner.UI.Windows;
 
-namespace TerminalGuiDesigner.Operations;
+namespace TerminalGuiDesigner.Operations.TableViewOperations;
 
 /// <summary>
 /// Adds a new <see cref="DataColumn"/> to a <see cref="DataTable"/> hosted in a <see cref="TableView"/>.
@@ -21,16 +22,16 @@ public class AddColumnOperation : Operation
     /// <exception cref="ArgumentException">Thrown if <paramref name="design"/> is not wrapping a <see cref="TableView"/>.</exception>
     public AddColumnOperation(Design design, string? newColumnName)
     {
-        this.Design = design;
+        Design = design;
         this.newColumnName = newColumnName;
 
         // somehow user ran this command for a non table view
-        if (this.Design.View is not TableView)
+        if (Design.View is not TableView)
         {
             throw new ArgumentException($"Design must be for a {nameof(TableView)} to support {nameof(AddColumnOperation)}");
         }
 
-        this.tableView = (TableView)this.Design.View;
+        tableView = (TableView)Design.View;
     }
 
     /// <summary>
@@ -42,37 +43,37 @@ public class AddColumnOperation : Operation
     public override void Redo()
     {
         // cannot redo (maybe user hit redo twice thats fine)
-        if (this.column == null || this.tableView.Table.Columns.Contains(this.column.ColumnName))
+        if (column == null || tableView.Table.Columns.Contains(column.ColumnName))
         {
             return;
         }
 
-        this.tableView.Table.Columns.Add(this.column);
-        this.tableView.Update();
+        tableView.Table.Columns.Add(column);
+        tableView.Update();
     }
 
     /// <inheritdoc/>
     public override void Undo()
     {
         // cannot undo
-        if (this.column == null || !this.tableView.Table.Columns.Contains(this.column.ColumnName))
+        if (column == null || !tableView.Table.Columns.Contains(column.ColumnName))
         {
             return;
         }
 
-        this.tableView.Table.Columns.Remove(this.column);
-        this.tableView.Update();
+        tableView.Table.Columns.Remove(column);
+        tableView.Update();
     }
 
     /// <inheritdoc/>
     protected override bool DoImpl()
     {
-        if (this.column != null)
+        if (column != null)
         {
             throw new Exception("This command has already been performed once.  Use Redo instead of Do");
         }
 
-        string? name = this.newColumnName;
+        string? name = newColumnName;
 
         if (name == null)
         {
@@ -89,11 +90,11 @@ public class AddColumnOperation : Operation
             return false;
         }
 
-        name = name.MakeUnique(this.tableView.Table.Columns.Cast<DataColumn>().Select(c => c.ColumnName));
+        name = name.MakeUnique(tableView.Table.Columns.Cast<DataColumn>().Select(c => c.ColumnName));
 
         // Add the new column
-        this.column = this.tableView.Table.Columns.Add(name);
-        this.tableView.Update();
+        column = tableView.Table.Columns.Add(name);
+        tableView.Update();
 
         return true;
     }

--- a/src/Operations/TableViewOperations/ColumnOperation.cs
+++ b/src/Operations/TableViewOperations/ColumnOperation.cs
@@ -1,7 +1,7 @@
 ﻿using System.Data;
 using Terminal.Gui;
 
-namespace TerminalGuiDesigner.Operations;
+namespace TerminalGuiDesigner.Operations.TableViewOperations;
 
 /// <summary>
 /// Abstract base class for <see cref="Operation"/> which affect a <see cref="DataColumn"/> in a <see cref="TableView"/>.
@@ -19,6 +19,7 @@ public abstract class ColumnOperation : Operation
     {
         this.Design = design;
         this.Column = column;
+        this.Category = column.ColumnName;
 
         // somehow user ran this command for a non table view
         if (this.Design.View is not Terminal.Gui.TableView)
@@ -27,6 +28,11 @@ public abstract class ColumnOperation : Operation
         }
 
         this.TableView = (TableView)this.Design.View;
+
+        if (this.TableView.Table != column.Table)
+        {
+            throw new ArgumentException($"Column provided does not belong to the {nameof(Terminal.Gui.TableView)} Table");
+        }
     }
 
     /// <summary>

--- a/src/Operations/TableViewOperations/MoveColumnOperation.cs
+++ b/src/Operations/TableViewOperations/MoveColumnOperation.cs
@@ -1,0 +1,99 @@
+﻿using System.Data;
+using Terminal.Gui;
+
+namespace TerminalGuiDesigner.Operations.TableViewOperations;
+
+/// <summary>
+/// Moves a <see cref="DataColumn"/> left or right within the ordering
+/// of columns in a <see cref="TableView"/>.
+/// </summary>
+public class MoveColumnOperation : ColumnOperation
+{
+    /// <summary>
+    /// Gets the number of index positions the <see cref="DataColumn"/> will
+    /// be moved. Negative for left, positive for right.
+    /// </summary>
+    private readonly int adjustment;
+    private readonly int originalIdx;
+    private readonly int newIndex;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MoveColumnOperation"/> class.
+    /// Creates an operation that will change the ordering of columns within
+    /// a <see cref="TableView"/>.
+    /// </summary>
+    /// <param name="design">Wrapper for a <see cref="TableView"/>.</param>
+    /// <param name="column">The <see cref="DataColumn"/> to move.</param>
+    /// <param name="adjustment">Negative to move left, positive to move right.</param>
+    public MoveColumnOperation(Design design, DataColumn column, int adjustment)
+        : base(design, column)
+    {
+        if (this.TableView.Table.Columns.Count == 1)
+        {
+            this.IsImpossible = true;
+        }
+
+        this.originalIdx = column.Ordinal;
+
+        if (this.originalIdx == -1)
+        {
+            this.IsImpossible = true;
+            return;
+        }
+
+        // calculate new index without falling off array
+        this.newIndex = Math.Max(0, Math.Min(
+                    this.TableView.Table.Columns.Count - 1,
+                    this.originalIdx + adjustment));
+
+        // they are moving it nowhere?!
+        if (this.newIndex == this.originalIdx)
+        {
+            this.IsImpossible = true;
+        }
+
+        this.adjustment = adjustment;
+    }
+
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        if (this.adjustment == 0)
+        {
+            return $"Bad Command '{this.GetType().Name}'";
+        }
+
+        if (this.adjustment < 0)
+        {
+            return $"Move '{this.Column}' Left";
+        }
+
+        if (this.adjustment > 0)
+        {
+            return $"Move '{this.Column}' Right";
+        }
+
+        return base.ToString();
+    }
+
+    /// <inheritdoc/>
+    public override void Redo()
+    {
+        this.Do();
+    }
+
+    /// <inheritdoc/>
+    public override void Undo()
+    {
+        this.Column.SetOrdinal(this.originalIdx);
+        this.TableView.Update();
+    }
+
+    /// <inheritdoc/>
+    protected override bool DoImpl()
+    {
+        this.Column.SetOrdinal(this.newIndex);
+        this.TableView.Update();
+        return true;
+    }
+}

--- a/src/Operations/TableViewOperations/RemoveColumnOperation.cs
+++ b/src/Operations/TableViewOperations/RemoveColumnOperation.cs
@@ -1,7 +1,7 @@
 ﻿using System.Data;
 using Terminal.Gui;
 
-namespace TerminalGuiDesigner.Operations;
+namespace TerminalGuiDesigner.Operations.TableViewOperations;
 
 /// <summary>
 /// Removes a <see cref="DataColumn"/> from a <see cref="TableView"/>.
@@ -19,41 +19,41 @@ public class RemoveColumnOperation : ColumnOperation
     {
         // TODO: currently this crashes TableView in its ReDraw (calculate view port) method
         // don't let them remove the last column
-        if (this.TableView.Table.Columns.Count == 1)
+        if (TableView.Table.Columns.Count == 1)
         {
-            this.IsImpossible = true;
+            IsImpossible = true;
         }
     }
 
     /// <inheritdoc/>
     public override string ToString()
     {
-        return $"Remove Column '{this.Column}'";
+        return $"Remove Column '{Column}'";
     }
 
     /// <inheritdoc/>
     public override void Redo()
     {
-        this.Do();
+        Do();
     }
 
     /// <inheritdoc/>
     public override void Undo()
     {
-        if (!this.TableView.Table.Columns.Contains(this.Column.ColumnName))
+        if (!TableView.Table.Columns.Contains(Column.ColumnName))
         {
-            this.TableView.Table.Columns.Add(this.Column.ColumnName);
-            this.TableView.Update();
+            TableView.Table.Columns.Add(Column.ColumnName);
+            TableView.Update();
         }
     }
 
     /// <inheritdoc/>
     protected override bool DoImpl()
     {
-        if (this.TableView.Table.Columns.Contains(this.Column.ColumnName))
+        if (TableView.Table.Columns.Contains(Column.ColumnName))
         {
-            this.TableView.Table.Columns.Remove(this.Column.ColumnName);
-            this.TableView.Update();
+            TableView.Table.Columns.Remove(Column.ColumnName);
+            TableView.Update();
 
             return true;
         }

--- a/src/Operations/TableViewOperations/RenameColumnOperation.cs
+++ b/src/Operations/TableViewOperations/RenameColumnOperation.cs
@@ -3,7 +3,7 @@ using Terminal.Gui;
 using TerminalGuiDesigner.Operations;
 using TerminalGuiDesigner.UI.Windows;
 
-namespace TerminalGuiDesigner;
+namespace TerminalGuiDesigner.Operations.TableViewOperations;
 
 /// <summary>
 /// Renames a <see cref="DataColumn"/> in a <see cref="TableView"/>.
@@ -28,31 +28,31 @@ public class RenameColumnOperation : ColumnOperation
     /// <inheritdoc/>
     public override string ToString()
     {
-        return $"Rename Column '{this.originalName}'";
+        return $"Rename Column '{originalName}'";
     }
 
     /// <inheritdoc/>
     public override void Redo()
     {
-        this.Column.ColumnName = this.newColumnName;
-        this.TableView.Update();
+        Column.ColumnName = newColumnName;
+        TableView.Update();
     }
 
     /// <inheritdoc/>
     public override void Undo()
     {
-        this.Column.ColumnName = this.originalName;
-        this.TableView.Update();
+        Column.ColumnName = originalName;
+        TableView.Update();
     }
 
     /// <inheritdoc/>
     protected override bool DoImpl()
     {
-        if (Modals.GetString("Rename Column", "Column Name", this.originalName, out var newColumnName))
+        if (Modals.GetString("Rename Column", "Column Name", originalName, out var newColumnName))
         {
             this.newColumnName = newColumnName;
-            this.Column.ColumnName = newColumnName;
-            this.TableView.Update();
+            Column.ColumnName = newColumnName;
+            TableView.Update();
             return true;
         }
 

--- a/src/ToCode/ColorSchemeToCode.cs
+++ b/src/ToCode/ColorSchemeToCode.cs
@@ -18,7 +18,7 @@ public class ColorSchemeToCode : ToCodeBase
     /// Initializes a new instance of the <see cref="ColorSchemeToCode"/> class.
     /// </summary>
     /// <param name="scheme">The <see cref="ColorScheme"/> tracked by
-    /// <see cref="ColorSchemeManager"/> that is to be added to .Designer.cs</param>
+    /// <see cref="ColorSchemeManager"/> that is to be added to .Designer.cs.</param>
     public ColorSchemeToCode(NamedColorScheme scheme)
     {
         this.scheme = scheme;

--- a/src/ToCode/Property.cs
+++ b/src/ToCode/Property.cs
@@ -378,7 +378,7 @@ public class Property : ToCodeBase
 
     /// <summary>
     /// Calls any methods that update the state of the View
-    /// and refresh it against its style e.g. <see cref="TableView.Update"/>
+    /// and refresh it against its style e.g. <see cref="TableView.Update"/>.
     /// </summary>
     private void CallRefreshMethodsIfAny()
     {

--- a/src/UI/Windows/ExceptionHelper.cs
+++ b/src/UI/Windows/ExceptionHelper.cs
@@ -41,18 +41,6 @@ public static class ExceptionHelper
     }
 
     /// <summary>
-    /// Returns the first base Exception in the AggregateException.InnerExceptions list which is of type T
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="e"></param>
-    /// <returns></returns>
-    public static T? GetExceptionIfExists<T>(this AggregateException e)
-        where T : Exception
-    {
-        return e.Flatten().InnerExceptions.OfType<T>().FirstOrDefault();
-    }
-
-    /// <summary>
     /// Returns the first InnerException of type T in the Exception or null.
     ///
     /// <para>If e is T then e is returned directly</para>

--- a/src/UI/Windows/Modals.cs
+++ b/src/UI/Windows/Modals.cs
@@ -63,7 +63,8 @@ public class Modals
             WindowTitle = windowTitle,
             EntryLabel = entryLabel,
             MultiLine = true,
-        }, initialValue == null ? string.Empty : string.Join('\n', initialValue.ToList().Select(v => v?.ToString() ?? string.Empty)));
+        },
+            initialValue == null ? string.Empty : string.Join('\n', initialValue.ToList().Select(v => v?.ToString() ?? string.Empty)));
 
         if (dlg.ShowDialog())
         {
@@ -100,7 +101,8 @@ public class Modals
             WindowTitle = windowTitle,
             EntryLabel = entryLabel,
             MultiLine = multiLine,
-        }, initialValue);
+        },
+            initialValue);
 
         if (dlg.ShowDialog())
         {

--- a/tests/Operations/AddColumnOperationTests.cs
+++ b/tests/Operations/AddColumnOperationTests.cs
@@ -1,7 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using Terminal.Gui;
-using TerminalGuiDesigner.Operations;
+using TerminalGuiDesigner.Operations.TableViewOperations;
 
 namespace UnitTests.Operations;
 

--- a/tests/Operations/MoveColumnOperationTests.cs
+++ b/tests/Operations/MoveColumnOperationTests.cs
@@ -1,0 +1,87 @@
+﻿using NUnit.Framework;
+using System;
+using Terminal.Gui;
+using TerminalGuiDesigner;
+using TerminalGuiDesigner.Operations.TableViewOperations;
+
+namespace UnitTests.Operations
+{
+    internal class MoveColumnOperationTests : Tests
+    {
+        [Test]
+        public void TestMoveColumn_WrongViewType_Throws()
+        {
+            // Label is not a TableView so should get Exception
+            RoundTrip<Window, Label>((d, v) =>
+            {
+                Assert.Throws<ArgumentException>(()=>new MoveColumnOperation(d,new System.Data.DataColumn(), 1));
+            }, out _);
+        }
+
+        [Test]
+        public void TestMoveColumn_ColumnNotInTableView_Throws()
+        {
+            
+            RoundTrip<Window, TableView>((d, v) =>
+            {
+                // DataColumn is new and not in v.Table
+                Assert.Throws<ArgumentException>(() =>
+                    new MoveColumnOperation(d, new System.Data.DataColumn(), 1));
+            }, out _);
+        }
+
+
+        [Test]
+        public void TestMoveColumn_OnlyOneColumn_IsImpossible()
+        {
+            RoundTrip<Window, TableView>((d, v) =>
+            {
+                Assert.AreEqual(4, v.Table.Columns.Count, $"Expected {nameof(ViewFactory)} to create a {nameof(TableView)} with 4 example placeholder Columns");
+                v.Table.Columns.RemoveAt(1);
+                v.Table.Columns.RemoveAt(1);
+                v.Table.Columns.RemoveAt(1);
+                Assert.AreEqual(1, v.Table.Columns.Count);
+
+                Assert.IsTrue(new MoveColumnOperation(d, v.Table.Columns[0],1).IsImpossible,"Should be impossible to move Column when there is only one of them");
+            }, out _);
+        }
+
+        [TestCase(3,-8,0,true)] // move left lots
+        [TestCase(2, 55, 4, true)] // move right lots
+        [TestCase(0, 0, 0, false)] // move 0 nowhere
+        [TestCase(0, 1, 1, true)] // move 0 right 1
+        [TestCase(1, -1, 0, true)] // move 1 left 1
+        public void TestMoveColumn_DoUndo(int idxToMove, int adjustment, int expectedNewIndex, bool expectPossible)
+        {
+            RoundTrip<Window, TableView>((d, v) =>
+            {
+                Assert.AreEqual(4, v.Table.Columns.Count, $"Expected {nameof(ViewFactory)} to create a {nameof(TableView)} with 4 example placeholder Columns");
+
+                var toMove = v.Table.Columns[idxToMove];
+                var originalIndex = toMove.Ordinal;
+
+                var op = new MoveColumnOperation(d, toMove, adjustment);
+
+                if(expectPossible)
+                {
+                    Assert.IsFalse(op.IsImpossible);
+                    Assert.IsTrue(op.Do());
+                }
+                else
+                {
+                    Assert.IsTrue(op.IsImpossible);
+                    Assert.False(op.Do());
+                }
+
+                Assert.AreEqual(expectedNewIndex, toMove.Ordinal);
+
+                op.Undo();
+                Assert.AreEqual(originalIndex, toMove.Ordinal);
+
+                op.Redo();
+                Assert.AreEqual(expectedNewIndex, toMove.Ordinal);
+
+            }, out _);
+        }
+    }
+}

--- a/tests/Operations/MoveColumnOperationTests.cs
+++ b/tests/Operations/MoveColumnOperationTests.cs
@@ -47,7 +47,7 @@ namespace UnitTests.Operations
         }
 
         [TestCase(3,-8,0,true)] // move left lots
-        [TestCase(2, 55, 4, true)] // move right lots
+        [TestCase(2, 55, 3, true)] // move right lots
         [TestCase(0, 0, 0, false)] // move 0 nowhere
         [TestCase(0, 1, 1, true)] // move 0 right 1
         [TestCase(1, -1, 0, true)] // move 1 left 1


### PR DESCRIPTION
- Also move TableView operations to their own namespace 
- Also add Category field to IOperation to allow all column operations to be grouped together on context menu
- Also fixed a TODO where right clicking in 'header area' of a TableView would not know what cell (and therefore what header) user clicked.  Worse it would show the operations for the *selected cell/column* which could lead to mistakes.

![image](https://user-images.githubusercontent.com/31306100/202418479-0c1cdc5c-2153-4999-aefc-2f464ba16aaa.png)
