### PR TITLE
Improves MenuBar right click context menu

### DIFF
--- a/src/Design.cs
+++ b/src/Design.cs
@@ -417,10 +417,18 @@ public class Design
             yield return new MoveTabOperation(this, 1);
         }
 
-        if (this.View is MenuBar)
+        if (this.View is MenuBar mb)
         {
             yield return new AddMenuOperation(this, null);
-            yield return new RemoveMenuOperation(this);
+
+            var menu = mb.ScreenToMenuBarItem(pos.X);
+
+            if (menu != null)
+            {
+                yield return new RemoveMenuOperation(this,menu);
+                yield return new MoveMenuOperation(this, menu, -1);
+                yield return new MoveMenuOperation(this, menu, 1);
+            }
         }
     }
 

--- a/src/MenuBarExtensions.cs
+++ b/src/MenuBarExtensions.cs
@@ -49,7 +49,7 @@ public static class MenuBarExtensions
         var clientPoint = menuBar.ScreenToView(screenX, 0);
 
         // if click is not in our client area
-        if(screenX < initialWhitespace)
+        if (clientPoint.X < initialWhitespace)
         {
             return null;
         }
@@ -67,7 +67,15 @@ public static class MenuBarExtensions
         // anything after this is not a click on a menu
         menuXLocations.Add(distance, null);
 
-        return menuXLocations.Last(m => m.Key < clientPoint.X).Value;
+        // LastOrDefault does not work with Dictionaries, if we somehow still have a point outside bounds
+        // of anything then just return null;
+        if (!menuXLocations.Any(m => m.Key <= clientPoint.X))
+        {
+            return null;
+        }
+
+        // Return the last menu item that begins rendering before this X point
+        return menuXLocations.Last(m => m.Key <= clientPoint.X).Value;
     }
 
     private static object GetNonNullPrivateFieldValue(string fieldName, object item, Type type)

--- a/src/Operations/AddViewOperation.cs
+++ b/src/Operations/AddViewOperation.cs
@@ -9,9 +9,9 @@ namespace TerminalGuiDesigner.Operations;
 /// </summary>
 public class AddViewOperation : Operation
 {
+    private readonly Design to;
     private View? add;
     private string? fieldName;
-    private readonly Design to;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AddViewOperation"/> class.

--- a/src/Operations/MenuOperations/MoveMenuOperation.cs
+++ b/src/Operations/MenuOperations/MoveMenuOperation.cs
@@ -1,0 +1,106 @@
+﻿using Terminal.Gui;
+
+namespace TerminalGuiDesigner.Operations.MenuOperations;
+
+/// <summary>
+/// Moves a top level <see cref="MenuBarItem"/> (File, Edit etc) left or right within the ordering
+/// of menus in a <see cref="MenuBar"/>.
+/// </summary>
+public class MoveMenuOperation : Operation
+{
+    /// <summary>
+    /// Gets the number of index positions the <see cref="MenuBarItem"/> will
+    /// be moved. Negative for left, positive for right.
+    /// </summary>
+    private readonly int adjustment;
+    private readonly int originalIdx;
+    private readonly int newIndex;
+    private MenuBar menuBar;
+    private MenuBarItem toMove;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MoveMenuOperation"/> class.
+    /// Creates an operation that will change the ordering of top level menus within
+    /// a <see cref="MenuBar"/>.
+    /// </summary>
+    /// <param name="design">Wrapper for a <see cref="MenuBar"/>.</param>
+    /// <param name="toMove">The top level menu to move.</param>
+    /// <param name="adjustment">Negative to move menu left, positive to move menu right.</param>
+    public MoveMenuOperation(Design design, MenuBarItem toMove, int adjustment)
+    {
+        if (design.View is not MenuBar mb)
+        {
+            throw new ArgumentException($"Design must wrap a {nameof(MenuBar)} to be used with this method.");
+        }
+
+        this.menuBar = mb;
+        this.toMove = toMove;
+        this.originalIdx = Array.IndexOf(this.menuBar.Menus, toMove);
+
+        if (this.originalIdx == -1)
+        {
+            throw new ArgumentException(nameof(toMove), $"{nameof(toMove)} {nameof(MenuBarItem)} did not belong to the passed {nameof(design)}");
+        }
+
+        // calculate new index without falling off array
+        this.newIndex = Math.Max(0, Math.Min(this.menuBar.Menus.Length - 1, this.originalIdx + adjustment));
+
+        // they are moving it nowhere?!
+        if (this.newIndex == this.originalIdx)
+        {
+            this.IsImpossible = true;
+        }
+
+        this.adjustment = adjustment;
+    }
+
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        if (this.adjustment == 0)
+        {
+            return $"Bad Command '{this.GetType().Name}'";
+        }
+
+        if (this.adjustment < 0)
+        {
+            return $"Move '{this.toMove.Title}' Left";
+        }
+
+        if (this.adjustment > 0)
+        {
+            return $"Move '{this.toMove.Title}' Right";
+        }
+
+        return base.ToString();
+    }
+
+    /// <inheritdoc/>
+    public override void Redo()
+    {
+        this.Do();
+    }
+
+    /// <inheritdoc/>
+    public override void Undo()
+    {
+        var menus = this.menuBar.Menus.ToList();
+
+        menus.Remove(this.toMove);
+        menus.Insert(this.originalIdx, this.toMove);
+
+        this.menuBar.Menus = menus.Cast<MenuBarItem>().ToArray();
+    }
+
+    /// <inheritdoc/>
+    protected override bool DoImpl()
+    {
+        var menus = this.menuBar.Menus.ToList();
+
+        menus.Remove(this.toMove);
+        menus.Insert(this.newIndex, this.toMove);
+
+        this.menuBar.Menus = menus.Cast<MenuBarItem>().ToArray();
+        return true;
+    }
+}

--- a/src/Operations/MenuOperations/MoveMenuOperation.cs
+++ b/src/Operations/MenuOperations/MoveMenuOperation.cs
@@ -52,6 +52,8 @@ public class MoveMenuOperation : Operation
         }
 
         this.adjustment = adjustment;
+
+        this.Category = this.toMove.Title?.ToString() ?? "blank menu";
     }
 
     /// <inheritdoc/>
@@ -90,6 +92,7 @@ public class MoveMenuOperation : Operation
         menus.Insert(this.originalIdx, this.toMove);
 
         this.menuBar.Menus = menus.Cast<MenuBarItem>().ToArray();
+        this.menuBar.SetNeedsDisplay();
     }
 
     /// <inheritdoc/>
@@ -101,6 +104,7 @@ public class MoveMenuOperation : Operation
         menus.Insert(this.newIndex, this.toMove);
 
         this.menuBar.Menus = menus.Cast<MenuBarItem>().ToArray();
+        this.menuBar.SetNeedsDisplay();
         return true;
     }
 }

--- a/src/Operations/MenuOperations/RemoveMenuOperation.cs
+++ b/src/Operations/MenuOperations/RemoveMenuOperation.cs
@@ -17,21 +17,27 @@ public class RemoveMenuOperation : Operation
     /// Initializes a new instance of the <see cref="RemoveMenuOperation"/> class.
     /// </summary>
     /// <param name="design">Wrapper for a <see cref="MenuBar"/> upon which you wish to operate.</param>
+    /// <param name="toRemove">The <see cref="MenuBarItem"/> to remove.</param>
     /// <exception cref="ArgumentException">Thrown if <paramref name="design"/> does not wrap a <see cref="MenuBar"/>.</exception>
-    public RemoveMenuOperation(Design design)
+    public RemoveMenuOperation(Design design, MenuBarItem toRemove)
     {
         this.Design = design;
+        this.toRemove = toRemove;
 
         // somehow user ran this command for a non tab view
-        if (this.Design.View is not MenuBar)
+        if (this.Design.View is not MenuBar mb)
         {
             throw new ArgumentException($"Design must be for a {nameof(MenuBar)} to support {nameof(AddMenuOperation)}");
         }
 
-        this.menuBar = (MenuBar)this.Design.View;
-        this.toRemove = this.menuBar.GetSelectedMenuItem();
+        this.menuBar = mb;
 
-        this.IsImpossible = this.toRemove == null;
+        if (!this.menuBar.Menus.Contains(toRemove))
+        {
+            throw new ArgumentException(nameof(toRemove), $"{nameof(toRemove)} {nameof(MenuBarItem)} did not belong to the passed {nameof(design)}");
+        }
+
+        this.Category = this.toRemove.Title?.ToString() ?? "blank menu";
     }
 
     /// <summary>

--- a/src/Operations/SetPropertyOperation.cs
+++ b/src/Operations/SetPropertyOperation.cs
@@ -76,7 +76,7 @@ public class SetPropertyOperation : Operation
     /// <param name="propertyName">The name of a designable <see cref="Property"/> on
     /// all the <paramref name="designs"/> (See <see cref="Design.GetDesignableProperties"/>).</param>
     /// <param name="valueGetter">Delegate for fetching the new value for
-    /// the <paramref name="propertyName"/> when command is run e.g. via a <see cref="Modals"/></param>
+    /// the <paramref name="propertyName"/> when command is run e.g. via a <see cref="Modals"/>.</param>
     /// <exception cref="ArgumentException">Thrown if <paramref name="propertyName"/> is not found amongst <paramref name="designs"/> properties.</exception>
     public SetPropertyOperation(Design[] designs, string propertyName, PropertyValueGetterDelegate valueGetter)
     {
@@ -157,10 +157,9 @@ public class SetPropertyOperation : Operation
                 // for this property?
                 var currentVals = this.mementos.Select(p => p.Property.GetValue()).Distinct().ToArray();
 
+                // are we setting multiple at once? and the current values are different? If so then pass null for current value (no consensus)
                 this.NewValue = currentVals.Length == 1 ?
-                    // yes
                     this.valueGetter(this.mementos[0].Property, currentVals[0]) :
-                    // we are setting multiple at once and the current values are different so just tell the user theres no value
                     this.valueGetter(this.mementos[0].Property, null);
             }
             catch (OperationCanceledException)

--- a/src/SourceCodeFile.cs
+++ b/src/SourceCodeFile.cs
@@ -36,16 +36,6 @@ public class SourceCodeFile
     }
 
     /// <summary>
-    /// Gets the .cs file (e.g. MyView.cs).
-    /// </summary>
-    public FileInfo CsFile { get; }
-
-    /// <summary>
-    /// Gets the .Designer.cs file (e.g. MyView.Designer.cs).
-    /// </summary>
-    public FileInfo DesignerFile { get; }
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="SourceCodeFile"/> class.
     /// Declares a new pair of files (e.g. MyClass.cs and MyClass.Designer.cs) which
     /// may or may not both exist yet.
@@ -55,6 +45,16 @@ public class SourceCodeFile
         : this(new FileInfo(path))
     {
     }
+
+    /// <summary>
+    /// Gets the .cs file (e.g. MyView.cs).
+    /// </summary>
+    public FileInfo CsFile { get; }
+
+    /// <summary>
+    /// Gets the .Designer.cs file (e.g. MyView.Designer.cs).
+    /// </summary>
+    public FileInfo DesignerFile { get; }
 
     /// <summary>
     /// Returns the .Designer.cs file for the given class file.

--- a/src/UI/Windows/BigListBox.cs
+++ b/src/UI/Windows/BigListBox.cs
@@ -161,6 +161,19 @@ public class BigListBox<T>
     /// </summary>
     public Func<T?, string> AspectGetter { get; set; }
 
+    /// <summary>
+    /// Runs the dialog as modal blocking and returns true if a selection was made.
+    /// </summary>
+    /// <returns>True if selection was made (see <see cref="Selected"/>) or false if user cancelled the dialog</returns>
+    public bool ShowDialog()
+    {
+        Application.Run(this.win);
+
+        Application.MainLoop.RemoveTimeout(this.callback);
+
+        return this.okClicked;
+    }
+
     private void Accept()
     {
         if (this.listView.SelectedItem >= this.collection.Count)
@@ -180,19 +193,6 @@ public class BigListBox<T>
             obj.Handled = true;
             this.Accept();
         }
-    }
-
-    /// <summary>
-    /// Runs the dialog as modal blocking and returns true if a selection was made.
-    /// </summary>
-    /// <returns>True if selection was made (see <see cref="Selected"/>) or false if user cancelled the dialog</returns>
-    public bool ShowDialog()
-    {
-        Application.Run(this.win);
-
-        Application.MainLoop.RemoveTimeout(this.callback);
-
-        return this.okClicked;
     }
 
     private void _listView_KeyPress(View.KeyEventEventArgs obj)

--- a/tests/MenuBarExtensionsTests.cs
+++ b/tests/MenuBarExtensionsTests.cs
@@ -1,0 +1,131 @@
+﻿using NUnit.Framework;
+using Terminal.Gui;
+using TerminalGuiDesigner;
+using TerminalGuiDesigner.Operations.MenuOperations;
+
+namespace UnitTests
+{
+    internal class MenuBarExtensionsTests : Tests
+    {
+        [Test]
+        public void TestScreenToMenuBarItem_AtOrigin_OneMenuItem()
+        {
+            RoundTrip<View, MenuBar>((d, v) => 
+            {
+                // Expect a MenuBar to be rendered that is 
+                // ".test.." (with 1 unit of preceding whitespace and 2 after)
+                // Note that this test is brittle and subject to changes in Terminal.Gui e.g. pushing menus closer together.
+                v.Menus[0].Title = "test";
+
+                Assert.IsNull(v.ScreenToMenuBarItem(0),
+                    "Expected Terminal.Gui MenuBar to have 1 unit of whitespace before any MenuBarItems (e.g. File) get rendered. This may change in future, if so then update this test.");
+                
+                // Clicks in the "test" region
+                Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(1));
+                Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(2));
+                Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(3));
+                Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(4));
+
+                // Clicks in the whitespace after "test" but before any other menus (of which there are none in this test btw)
+                Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5));
+                Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(6));
+
+                Assert.IsNull(v.ScreenToMenuBarItem(7), "Expected a click here to be off the end of the Menu 'test' + 2 whitespace characters");
+            }, out _);
+        }
+
+        [Test]
+        public void TestScreenToMenuBarItem_AtOrigin_MultipleMenuItem()
+        {
+            RoundTrip<View, MenuBar>((d, v) =>
+            {
+                // Expect a MenuBar to be rendered that is 
+                // ".test..next..more.." (with 1 unit of preceding whitespace and 2 after each)
+                // Note that this test is brittle and subject to changes in Terminal.Gui e.g. pushing menus closer together.
+                v.Menus[0].Title = "test";
+
+                new AddMenuOperation(d, "next").Do();
+                new AddMenuOperation(d, "more").Do();
+
+                Assert.IsNull(v.ScreenToMenuBarItem(0));
+
+                // Clicks in the "test" region
+                Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(1));
+                Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(2));
+                Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(3));
+                Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(4));
+                Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5));
+                Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(6));
+
+                // Clicks in the "next" region
+                Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(7));
+                Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(8));
+                Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(9));
+                Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(10));
+                Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(11));
+                Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(12));
+
+
+                // Clicks in the "more" region
+                Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(13));
+                Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(14));
+                Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(15));
+                Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(16));
+                Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(17));
+                Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(18));
+
+                // clicks off the end of the right
+                Assert.IsNull(v.ScreenToMenuBarItem(19));
+            }, out _);
+        }
+
+        [Test]
+        public void TestScreenToMenuBarItem_WithOffset_MultipleMenuItem()
+        {
+            RoundTrip<View, MenuBar>((d, v) =>
+            {
+                // Start the MenuBar a bit along the screen
+                v.X = 5;
+                v.Y = 1;
+
+                // Expect a MenuBar to be rendered that is 
+                // ".test..next..more.." (with 1 unit of preceding whitespace and 2 after each)
+                // Note that this test is brittle and subject to changes in Terminal.Gui e.g. pushing menus closer together.
+                v.Menus[0].Title = "test";
+
+                new AddMenuOperation(d, "next").Do();
+                new AddMenuOperation(d, "more").Do();
+
+                Assert.IsNull(v.ScreenToMenuBarItem(5+0));
+
+                // Clicks in the "test" region
+                Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5+1));
+                Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5+2));
+                Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5+3));
+                Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5+4));
+                Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5+5));
+                Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5+6));
+
+                // Clicks in the "next" region
+                Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(5+7));
+                Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(5+8));
+                Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(5+9));
+                Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(5+10));
+                Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(5+11));
+                Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(5+12));
+
+
+                // Clicks in the "more" region
+                Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(5+13));
+                Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(5+14));
+                Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(5+15));
+                Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(5+16));
+                Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(5+17));
+                Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(5+18));
+
+                // clicks off the end of the right
+                Assert.IsNull(v.ScreenToMenuBarItem(5+19));
+            }, out _);
+        }
+    }
+}

--- a/tests/Operations/MoveMenuOperationTests.cs
+++ b/tests/Operations/MoveMenuOperationTests.cs
@@ -1,0 +1,83 @@
+﻿using NUnit.Framework;
+using System;
+using System.Linq;
+using Terminal.Gui;
+using TerminalGuiDesigner;
+using TerminalGuiDesigner.Operations.MenuOperations;
+
+namespace UnitTests.Operations
+{
+    internal class MoveMenuOperationTests : Tests
+    {
+        [Test]
+        public void TestMoveMenu_WrongViewType_Throws()
+        {
+            // Label is not a MenuBar so should get Exception
+            RoundTrip<Window, Label>((d, v) =>
+            {
+                Assert.Throws<ArgumentException>(()=>new MoveMenuOperation(d,new MenuBarItem(), 1));
+            }, out _);
+        }
+
+        [Test]
+        public void TestMoveMenu_MenuBarItemDoesNotBelongToMenuBar_Throws()
+        {
+            RoundTrip<Window, MenuBar>((d, v) =>
+            {
+                // we passed a new MenuBarItem which will not belong to d and therefore should be an Exception
+                Assert.Throws<ArgumentException>(() => new MoveMenuOperation(d, new MenuBarItem(), 1));
+            }, out _);
+        }
+
+        [Test]
+        public void TestMoveMenu_OnlyOneMenu_IsImpossible()
+        {
+            RoundTrip<Window, MenuBar>((d, v) =>
+            {
+                Assert.AreEqual(1, v.Menus.Length, $"Expected {nameof(ViewFactory)} to create a {nameof(MenuBar)} with 1 example placeholder Menu");
+                Assert.IsTrue(new MoveMenuOperation(d, v.Menus[0], 1).IsImpossible,"Should be impossible to move Menu when there is only one of them");
+            }, out _);
+        }
+
+        [TestCase(3,-8,0,true)] // move left lots
+        [TestCase(3, 55, 5, true)] // move right lots
+        [TestCase(0, 0, 0, false)] // move 0 nowhere
+        [TestCase(0, 1, 1, true)] // move 0 right 1
+        [TestCase(1, -1, 0, true)] // move 1 left 1
+        public void TestMoveMenu_DoUndo(int idxToMove, int adjustment, int expectedNewIndex, bool expectPossible)
+        {
+            RoundTrip<Window, MenuBar>((d, v) =>
+            {
+                new AddMenuOperation(d, "NewMenu").Do();
+                new AddMenuOperation(d, "NewMenu").Do();
+                new AddMenuOperation(d, "NewMenu").Do();
+                new AddMenuOperation(d, "NewMenu").Do();
+                new AddMenuOperation(d, "NewMenu").Do();
+
+                var toMove = v.Menus.ElementAt(idxToMove);
+                var originalIndex = v.Menus.IndexOf(toMove);
+                var op = new MoveMenuOperation(d, toMove, adjustment);
+
+                if(expectPossible)
+                {
+                    Assert.IsFalse(op.IsImpossible);
+                    Assert.IsTrue(op.Do());
+                }
+                else
+                {
+                    Assert.IsTrue(op.IsImpossible);
+                    Assert.False(op.Do());
+                }
+
+                Assert.AreEqual(expectedNewIndex, v.Menus.IndexOf(toMove));
+
+                op.Undo();
+                Assert.AreEqual(originalIndex, v.Menus.IndexOf(toMove));
+
+                op.Redo();
+                Assert.AreEqual(expectedNewIndex, v.Menus.IndexOf(toMove));
+
+            }, out _);
+        }
+    }
+}


### PR DESCRIPTION
PR adds the following changes:

- Right clicking a MenuBar now brings up context menu of the MenuBarItem you right clicked not the selected one
- MenuBarItem operations are grouped under a Category of the name of the Menu
- Adds the MoveMenuOperation to reorder top level menus

Also adds:

- Context menu items that are not in a category now  appear in alphabetical order.