### PR TITLE
Fixes #224. Border BorderBrush and Background causes compiler error when his value is -1.

### DIFF
--- a/src/Design.cs
+++ b/src/Design.cs
@@ -155,17 +155,9 @@ public class Design
         // HACK: if you don't pull the label out first it complains that you cant set Focusable to true
         // on the Label because its super is not focusable :(
         var super = subView.SuperView;
-        var borderBrush = subView.Border != null ? subView.Border.BorderBrush : (Color)(-1);
-        var background = subView.Border != null ? subView.Border.Background : (Color)(-1);
-        if (super != null && super.Subviews.FirstOrDefault(sv => sv == subView && sv.Data == subView.Data) != null)
+        if (super != null)
         {
-            this.logger.Info($"Found and removing subView of Type '{subView.GetType()}' in the superView'{super}'");
             super.Remove(subView);
-            if (subView.Border != null)
-            {
-                subView.Border.BorderBrush = (Color)borderBrush!;
-                subView.Border.Background = (Color)background!;
-            }
         }
 
         // all views can be focused so that they can be edited

--- a/src/Design.cs
+++ b/src/Design.cs
@@ -782,26 +782,6 @@ public class Design
         }
     }
 
-    private Color GetBorderBorderBrush()
-    {
-        if (this.View.Border.BorderBrush == (Color)(-1) && this.View.Border.Parent.ColorScheme != null)
-        {
-            return this.View.Border.Parent.ColorScheme.Normal.Foreground;
-        }
-
-        return this.View.Border.BorderBrush;
-    }
-
-    private Color GetBorderBackground()
-    {
-        if (this.View.Border.Background == (Color)(-1) && this.View.Border.Parent.ColorScheme != null)
-        {
-            return this.View.Border.Parent.ColorScheme.Normal.Background;
-        }
-
-        return this.View.Border.Background;
-    }
-
     private bool ShowTextProperty()
     {
         // never show Text for root because it's almost certainly a container
@@ -816,16 +796,6 @@ public class Design
 
     private Property CreateSubProperty(string name, string subObjectName, object subObject)
     {
-        if (name == "BorderBrush")
-        {
-            this.View.Border.BorderBrush = this.GetBorderBorderBrush();
-        }
-
-        if (name == "Background")
-        {
-            this.View.Border.Background = this.GetBorderBackground();
-        }
-
         return new Property(
             this,
             subObject.GetType().GetProperty(name) ?? throw new Exception($"Could not find expected Property '{name}' on Sub Object of Type '{subObject.GetType()}'"),

--- a/src/Design.cs
+++ b/src/Design.cs
@@ -673,6 +673,7 @@ public class Design
         {
             yield return this.CreateSubProperty(nameof(Border.BorderStyle), nameof(this.View.Border), this.View.Border);
             yield return this.CreateSubProperty(nameof(Border.BorderBrush), nameof(this.View.Border), this.View.Border);
+            yield return this.CreateSubProperty(nameof(Border.Background), nameof(this.View.Border), this.View.Border);
             yield return this.CreateSubProperty(nameof(Border.Effect3D), nameof(this.View.Border), this.View.Border);
             yield return this.CreateSubProperty(nameof(Border.Effect3DBrush), nameof(this.View.Border), this.View.Border);
             yield return this.CreateSubProperty(nameof(Border.DrawMarginFrame), nameof(this.View.Border), this.View.Border);

--- a/src/Design.cs
+++ b/src/Design.cs
@@ -155,9 +155,17 @@ public class Design
         // HACK: if you don't pull the label out first it complains that you cant set Focusable to true
         // on the Label because its super is not focusable :(
         var super = subView.SuperView;
-        if (super != null)
+        var borderBrush = subView.Border != null ? subView.Border.BorderBrush : (Color)(-1);
+        var background = subView.Border != null ? subView.Border.Background : (Color)(-1);
+        if (super != null && super.Subviews.FirstOrDefault(sv => sv == subView && sv.Data == subView.Data) != null)
         {
+            this.logger.Info($"Found and removing subView of Type '{subView.GetType()}' in the superView'{super}'");
             super.Remove(subView);
+            if (subView.Border != null)
+            {
+                subView.Border.BorderBrush = (Color)borderBrush!;
+                subView.Border.Background = (Color)background!;
+            }
         }
 
         // all views can be focused so that they can be edited

--- a/src/Design.cs
+++ b/src/Design.cs
@@ -654,6 +654,7 @@ public class Design
         if (this.View is Toplevel)
         {
             yield return this.CreateProperty(nameof(Toplevel.Modal));
+            yield return this.CreateProperty(nameof(Toplevel.IsMdiContainer));
         }
 
         // Allow changing the FieldName on anything but root where

--- a/src/Design.cs
+++ b/src/Design.cs
@@ -782,6 +782,26 @@ public class Design
         }
     }
 
+    private Color GetBorderBorderBrush()
+    {
+        if (this.View.Border.BorderBrush == (Color)(-1) && this.View.Border.Parent.ColorScheme != null)
+        {
+            return this.View.Border.Parent.ColorScheme.Normal.Foreground;
+        }
+
+        return this.View.Border.BorderBrush;
+    }
+
+    private Color GetBorderBackground()
+    {
+        if (this.View.Border.Background == (Color)(-1) && this.View.Border.Parent.ColorScheme != null)
+        {
+            return this.View.Border.Parent.ColorScheme.Normal.Background;
+        }
+
+        return this.View.Border.Background;
+    }
+
     private bool ShowTextProperty()
     {
         // never show Text for root because it's almost certainly a container
@@ -796,6 +816,16 @@ public class Design
 
     private Property CreateSubProperty(string name, string subObjectName, object subObject)
     {
+        if (name == "BorderBrush")
+        {
+            this.View.Border.BorderBrush = this.GetBorderBorderBrush();
+        }
+
+        if (name == "Background")
+        {
+            this.View.Border.Background = this.GetBorderBackground();
+        }
+
         return new Property(
             this,
             subObject.GetType().GetProperty(name) ?? throw new Exception($"Could not find expected Property '{name}' on Sub Object of Type '{subObject.GetType()}'"),

--- a/src/Design.cs
+++ b/src/Design.cs
@@ -163,8 +163,8 @@ public class Design
             super.Remove(subView);
             if (subView.Border != null)
             {
-                subView.Border.BorderBrush = (Color)borderBrush!;
-                subView.Border.Background = (Color)background!;
+                subView.Border.BorderBrush = borderBrush!;
+                subView.Border.Background = background!;
             }
         }
 

--- a/src/Design.cs
+++ b/src/Design.cs
@@ -163,8 +163,8 @@ public class Design
             super.Remove(subView);
             if (subView.Border != null)
             {
-                subView.Border.BorderBrush = borderBrush!;
-                subView.Border.Background = background!;
+                subView.Border.BorderBrush = (Color)borderBrush!;
+                subView.Border.Background = (Color)background!;
             }
         }
 

--- a/src/FromCode/CodeToView.cs
+++ b/src/FromCode/CodeToView.cs
@@ -147,7 +147,7 @@ public class CodeToView
         var dd = typeof(Enumerable).GetTypeInfo().Assembly.Location;
         var coreDir = Directory.GetParent(dd) ?? throw new Exception($"Could not find parent directory of dotnet sdk.  Sdk directory was {dd}");
 
-        var references = new List<MetadataReference>(ReferenceAssemblies.Net60);
+        var references = new List<MetadataReference>(Net70.References.All);
 
         references.Add(MetadataReference.CreateFromFile(typeof(View).Assembly.Location));
         references.Add(MetadataReference.CreateFromFile(typeof(ustring).Assembly.Location));

--- a/src/FromCode/CodeToView.cs
+++ b/src/FromCode/CodeToView.cs
@@ -18,7 +18,7 @@ namespace TerminalGuiDesigner.FromCode;
 /// </summary>
 /// <remarks>
 /// Compiling requires having the correct assembly references for dependencies.  This is handled
-/// by <see cref="CompileAssembly"/>.  Most references come from <see cref="ReferenceAssemblies.Net60"/>
+/// by <see cref="CompileAssembly"/>.  Most references come from <see cref="Net70.References"/>
 /// but also <see cref="Terminal.Gui"/>.
 /// </remarks>
 public class CodeToView

--- a/src/TerminalGuiDesigner.csproj
+++ b/src/TerminalGuiDesigner.csproj
@@ -134,7 +134,7 @@
 		</Content>
 	</ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Basic.Reference.Assemblies" Version="1.4.5" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net70" Version="1.4.5" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
     <PackageReference Include="nlog" Version="5.2.3" />

--- a/src/TerminalGuiDesigner.csproj
+++ b/src/TerminalGuiDesigner.csproj
@@ -18,7 +18,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>TerminalGuiDesigner</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <PackageId>TerminalGuiDesigner</PackageId>
     <Version>1.0.24</Version>

--- a/src/TerminalGuiDesigner.csproj
+++ b/src/TerminalGuiDesigner.csproj
@@ -134,17 +134,17 @@
 		</Content>
 	</ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Basic.Reference.Assemblies" Version="1.4.1" />
+    <PackageReference Include="Basic.Reference.Assemblies" Version="1.4.5" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
-    <PackageReference Include="nlog" Version="5.1.3" />
-    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.435">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
+    <PackageReference Include="nlog" Version="5.2.3" />
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.CodeDom" Version="7.0.0" />
-    <PackageReference Include="Terminal.gui" Version="1.10.1" />
-    <PackageReference Include="YamlDotNet" Version="13.1.0" />
+    <PackageReference Include="Terminal.gui" Version="1.13.5" />
+    <PackageReference Include="YamlDotNet" Version="13.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/TerminalGuiDesigner.csproj
+++ b/src/TerminalGuiDesigner.csproj
@@ -25,7 +25,7 @@
     <Authors>Thomas Nind</Authors>
     <Nullable>enable</Nullable>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Description>Command line visual designer tool for creating Terminal.Gui C# applications.  Create and edit Termianl.Gui views as easily as you could with the Windows Forms Designer.  All generated code is contained in a seperate file (e.g. MyControl.Designer.cs).  Run the tool by calling directly from the command line 'TerminalGuiDesigner'</Description>
+    <Description>Command line visual designer tool for creating Terminal.Gui C# applications.  Create and edit Termianl.Gui views as easily as you could with the Windows Forms Designer.  All generated code is contained in a separate file (e.g. MyControl.Designer.cs).  Run the tool by calling directly from the command line 'TerminalGuiDesigner'</Description>
     <Owners>Thomas Nind</Owners>
     <Title>TerminalGuiDesigner does for Terminal.Gui what the Windows Forms Designer does for WinForms</Title>
     <PackageProjectUrl>https://github.com/tznind/TerminalGuiDesigner/</PackageProjectUrl>

--- a/src/TerminalGuiDesigner.csproj
+++ b/src/TerminalGuiDesigner.csproj
@@ -143,8 +143,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.CodeDom" Version="7.0.0" />
-    <PackageReference Include="Terminal.gui" Version="1.13.5" />
-    <PackageReference Include="YamlDotNet" Version="13.2.0" />
+    <PackageReference Include="Terminal.gui" Version="1.14.0" />
+    <PackageReference Include="YamlDotNet" Version="13.3.1" />
   </ItemGroup>
 
 </Project>

--- a/src/ToCode/ViewToCode.cs
+++ b/src/ToCode/ViewToCode.cs
@@ -175,7 +175,7 @@ public class ViewToCode
 
             File.WriteAllText(
                 file.DesignerFile.FullName,
-                TrimHeader(sw.ToString()));
+                TrimHeader(sw.ToString().Replace("Terminal.Gui.Color.-1", "(Color)(-1)")));
         }
     }
 

--- a/src/ToCode/ViewToCode.cs
+++ b/src/ToCode/ViewToCode.cs
@@ -175,7 +175,7 @@ public class ViewToCode
 
             File.WriteAllText(
                 file.DesignerFile.FullName,
-                TrimHeader(sw.ToString().Replace("Terminal.Gui.Color.-1", "(Color)(-1)")));
+                TrimHeader(sw.ToString()));
         }
     }
 

--- a/tests/BorderColorTests.cs
+++ b/tests/BorderColorTests.cs
@@ -1,5 +1,9 @@
 ﻿using NUnit.Framework;
+using System.Linq;
+using System.Reflection;
 using Terminal.Gui;
+using TerminalGuiDesigner;
+using TerminalGuiDesigner.Operations;
 
 namespace UnitTests
 {
@@ -11,15 +15,78 @@ namespace UnitTests
             var result = RoundTrip<Window, FrameView>((d, v) =>
             {
                 // Our view should not have any border color to start with
-                Assert.AreEqual(-1,(int) v.Border.BorderBrush);
-                Assert.AreEqual(-1,(int) v.Border.Background);
+                Assert.AreEqual(-1, (int)v.Border.BorderBrush);
+                Assert.AreEqual(-1, (int)v.Border.Background);
 
-            },out _);
+            }, out _);
 
             // Since there were no changes we would expect them to stay the same
             // after reload
             Assert.AreEqual(-1, (int)result.Border.BorderBrush);
             Assert.AreEqual(-1, (int)result.Border.Background);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestCopyPasteContainer(bool alsoSelectSubElements)
+        {
+            RoundTrip<Window, FrameView>((d, v) =>
+                {
+                    new AddViewOperation(new Label(), d, "lbl1").Do();
+                    new AddViewOperation(new Label(), d, "lbl2").Do();
+
+                    Assert.AreEqual(2, v.GetActualSubviews().Count(), "Expected the FrameView to have 2 children (lbl1 and lbl2)");
+
+                    Design[] toCopy;
+
+                    if (alsoSelectSubElements)
+                    {
+                        var lbl1Design = (Design)d.View.GetActualSubviews().First().Data;
+                        Assert.AreEqual("lbl1", lbl1Design.FieldName);
+
+                        toCopy = new Design[] { d, lbl1Design };
+                    }
+                    else
+                    {
+                        toCopy = new[] { d };
+                    }
+
+                    // copy the FrameView
+                    Assert.IsTrue(new CopyOperation(toCopy).Do());
+
+                    var rootDesign = d.GetRootDesign();
+
+                    // paste the FrameView
+                    Assert.IsTrue(new PasteOperation(rootDesign).Do());
+
+                    var rootSubviews = rootDesign.View.GetActualSubviews();
+
+                    Assert.AreEqual(2, rootSubviews.Count, "Expected root to have 2 FrameView now");
+                    Assert.IsTrue(rootSubviews.All(v => v is FrameView));
+
+                    Assert.IsTrue(
+                        rootSubviews.All(f => f.GetActualSubviews().Count() == 2),
+                        "Expected both FrameView (copied and pasted) to have the full contents of 2 Labels");
+
+                    // Since there were no changes we would expect them to stay the same
+                    // after reload
+                    foreach (var rsv in rootSubviews)
+                    {
+                        Assert.AreEqual(-1, (int)rsv.Border.BorderBrush);
+                        Assert.AreEqual(-1, (int)rsv.Border.Background);
+                        Assert.Null(GetFieldValue<Color?>(rsv.Border, "borderBrush"));
+                        Assert.Null(GetFieldValue<Color?>(rsv.Border, "background"));
+                    }
+                }
+                , out _);
+        }
+
+        private T GetFieldValue<T>(object obj, string name)
+        {
+            // Set the flags so that private and public fields from instances will be found
+            var bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+            var field = obj.GetType().GetField(name, bindingFlags);
+            return (T)field?.GetValue(obj)!;
         }
     }
 }

--- a/tests/BorderColorTests.cs
+++ b/tests/BorderColorTests.cs
@@ -1,0 +1,25 @@
+﻿using NUnit.Framework;
+using Terminal.Gui;
+
+namespace UnitTests
+{
+    internal class BorderColorTests : Tests
+    {
+        [Test]
+        public void TestRoundTrip_BorderColors_NeverSet()
+        {
+            var result = RoundTrip<Window, FrameView>((d, v) =>
+            {
+                // Our view should not have any border color to start with
+                Assert.AreEqual(-1,(int) v.Border.BorderBrush);
+                Assert.AreEqual(-1,(int) v.Border.Background);
+
+            },out _);
+
+            // Since there were no changes we would expect them to stay the same
+            // after reload
+            Assert.AreEqual(-1, (int)result.Border.BorderBrush);
+            Assert.AreEqual(-1, (int)result.Border.Background);
+        }
+    }
+}

--- a/tests/UnitTests.csproj
+++ b/tests/UnitTests.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
-    <PackageReference Include="YamlDotNet" Version="13.1.0" />
-	  <PackageReference Include="ReportGenerator" Version="5.1.20" />
-	  <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="YamlDotNet" Version="13.2.0" />
+	  <PackageReference Include="ReportGenerator" Version="5.1.24" />
+	  <PackageReference Include="coverlet.collector" Version="6.0.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>

--- a/tests/UnitTests.csproj
+++ b/tests/UnitTests.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="YamlDotNet" Version="13.2.0" />
+    <PackageReference Include="YamlDotNet" Version="13.3.1" />
 	  <PackageReference Include="ReportGenerator" Version="5.1.24" />
 	  <PackageReference Include="coverlet.collector" Version="6.0.0">
 		  <PrivateAssets>all</PrivateAssets>

--- a/tests/UnitTests.csproj
+++ b/tests/UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Also updated to net7.0. Now the unit tests pass.

Now is possible to set the `Border.BorderBrush` and the `Border.Background`.

https://github.com/gui-cs/TerminalGuiDesigner/assets/13117724/f4d2f9ea-5200-47e8-a224-db62a0e232ac