### PR TITLE
Fix unit tests error on #224

### DIFF
--- a/src/Design.cs
+++ b/src/Design.cs
@@ -155,17 +155,9 @@ public class Design
         // HACK: if you don't pull the label out first it complains that you cant set Focusable to true
         // on the Label because its super is not focusable :(
         var super = subView.SuperView;
-        var borderBrush = subView.Border != null ? subView.Border.BorderBrush : (Color)(-1);
-        var background = subView.Border != null ? subView.Border.Background : (Color)(-1);
-        if (super != null && super.Subviews.FirstOrDefault(sv => sv == subView && sv.Data == subView.Data) != null)
+        if (super != null)
         {
-            this.logger.Info($"Found and removing subView of Type '{subView.GetType()}' in the superView'{super}'");
             super.Remove(subView);
-            if (subView.Border != null)
-            {
-                subView.Border.BorderBrush = (Color)borderBrush!;
-                subView.Border.Background = (Color)background!;
-            }
         }
 
         // all views can be focused so that they can be edited

--- a/src/Design.cs
+++ b/src/Design.cs
@@ -155,9 +155,17 @@ public class Design
         // HACK: if you don't pull the label out first it complains that you cant set Focusable to true
         // on the Label because its super is not focusable :(
         var super = subView.SuperView;
-        if (super != null)
+        var borderBrush = subView.Border != null ? subView.Border.BorderBrush : (Color)(-1);
+        var background = subView.Border != null ? subView.Border.Background : (Color)(-1);
+        if (super != null && super.Subviews.FirstOrDefault(sv => sv == subView && sv.Data == subView.Data) != null)
         {
+            this.logger.Info($"Found and removing subView of Type '{subView.GetType()}' in the superView'{super}'");
             super.Remove(subView);
+            if (subView.Border != null)
+            {
+                subView.Border.BorderBrush = (Color)borderBrush!;
+                subView.Border.Background = (Color)background!;
+            }
         }
 
         // all views can be focused so that they can be edited

--- a/src/Design.cs
+++ b/src/Design.cs
@@ -654,6 +654,7 @@ public class Design
         if (this.View is Toplevel)
         {
             yield return this.CreateProperty(nameof(Toplevel.Modal));
+            yield return this.CreateProperty(nameof(Toplevel.IsMdiContainer));
         }
 
         // Allow changing the FieldName on anything but root where

--- a/src/Design.cs
+++ b/src/Design.cs
@@ -163,8 +163,8 @@ public class Design
             super.Remove(subView);
             if (subView.Border != null)
             {
-                subView.Border.BorderBrush = (Color)borderBrush!;
-                subView.Border.Background = (Color)background!;
+                subView.Border.BorderBrush = borderBrush!;
+                subView.Border.Background = background!;
             }
         }
 

--- a/src/Design.cs
+++ b/src/Design.cs
@@ -163,8 +163,8 @@ public class Design
             super.Remove(subView);
             if (subView.Border != null)
             {
-                subView.Border.BorderBrush = borderBrush!;
-                subView.Border.Background = background!;
+                subView.Border.BorderBrush = (Color)borderBrush!;
+                subView.Border.Background = (Color)background!;
             }
         }
 

--- a/tests/BorderColorTests.cs
+++ b/tests/BorderColorTests.cs
@@ -1,5 +1,9 @@
 ﻿using NUnit.Framework;
+using System.Linq;
+using System.Reflection;
 using Terminal.Gui;
+using TerminalGuiDesigner;
+using TerminalGuiDesigner.Operations;
 
 namespace UnitTests
 {
@@ -11,15 +15,78 @@ namespace UnitTests
             var result = RoundTrip<Window, FrameView>((d, v) =>
             {
                 // Our view should not have any border color to start with
-                Assert.AreEqual(-1,(int) v.Border.BorderBrush);
-                Assert.AreEqual(-1,(int) v.Border.Background);
+                Assert.AreEqual(-1, (int)v.Border.BorderBrush);
+                Assert.AreEqual(-1, (int)v.Border.Background);
 
-            },out _);
+            }, out _);
 
             // Since there were no changes we would expect them to stay the same
             // after reload
             Assert.AreEqual(-1, (int)result.Border.BorderBrush);
             Assert.AreEqual(-1, (int)result.Border.Background);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestCopyPasteContainer(bool alsoSelectSubElements)
+        {
+            RoundTrip<Window, FrameView>((d, v) =>
+                {
+                    new AddViewOperation(new Label(), d, "lbl1").Do();
+                    new AddViewOperation(new Label(), d, "lbl2").Do();
+
+                    Assert.AreEqual(2, v.GetActualSubviews().Count(), "Expected the FrameView to have 2 children (lbl1 and lbl2)");
+
+                    Design[] toCopy;
+
+                    if (alsoSelectSubElements)
+                    {
+                        var lbl1Design = (Design)d.View.GetActualSubviews().First().Data;
+                        Assert.AreEqual("lbl1", lbl1Design.FieldName);
+
+                        toCopy = new Design[] { d, lbl1Design };
+                    }
+                    else
+                    {
+                        toCopy = new[] { d };
+                    }
+
+                    // copy the FrameView
+                    Assert.IsTrue(new CopyOperation(toCopy).Do());
+
+                    var rootDesign = d.GetRootDesign();
+
+                    // paste the FrameView
+                    Assert.IsTrue(new PasteOperation(rootDesign).Do());
+
+                    var rootSubviews = rootDesign.View.GetActualSubviews();
+
+                    Assert.AreEqual(2, rootSubviews.Count, "Expected root to have 2 FrameView now");
+                    Assert.IsTrue(rootSubviews.All(v => v is FrameView));
+
+                    Assert.IsTrue(
+                        rootSubviews.All(f => f.GetActualSubviews().Count() == 2),
+                        "Expected both FrameView (copied and pasted) to have the full contents of 2 Labels");
+
+                    // Since there were no changes we would expect them to stay the same
+                    // after reload
+                    foreach (var rsv in rootSubviews)
+                    {
+                        Assert.AreEqual(-1, (int)rsv.Border.BorderBrush);
+                        Assert.AreEqual(-1, (int)rsv.Border.Background);
+                        Assert.Null(GetFieldValue<Color?>(rsv.Border, "borderBrush"));
+                        Assert.Null(GetFieldValue<Color?>(rsv.Border, "background"));
+                    }
+                }
+                , out _);
+        }
+
+        private T GetFieldValue<T>(object obj, string name)
+        {
+            // Set the flags so that private and public fields from instances will be found
+            var bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+            var field = obj.GetType().GetField(name, bindingFlags);
+            return (T)field?.GetValue(obj)!;
         }
     }
 }

--- a/tests/BorderColorTests.cs
+++ b/tests/BorderColorTests.cs
@@ -1,0 +1,25 @@
+﻿using NUnit.Framework;
+using Terminal.Gui;
+
+namespace UnitTests
+{
+    internal class BorderColorTests : Tests
+    {
+        [Test]
+        public void TestRoundTrip_BorderColors_NeverSet()
+        {
+            var result = RoundTrip<Window, FrameView>((d, v) =>
+            {
+                // Our view should not have any border color to start with
+                Assert.AreEqual(-1,(int) v.Border.BorderBrush);
+                Assert.AreEqual(-1,(int) v.Border.Background);
+
+            },out _);
+
+            // Since there were no changes we would expect them to stay the same
+            // after reload
+            Assert.AreEqual(-1, (int)result.Border.BorderBrush);
+            Assert.AreEqual(-1, (int)result.Border.Background);
+        }
+    }
+}


### PR DESCRIPTION
I really don't know why the `BorderBrush` and the `Background` properties of the `Border` class change both to `Color.Black` after they are removed from the superView.