### PR TITLE
Add net8.0 configurations and conditional compilation

### DIFF
--- a/src/FromCode/CodeToView.cs
+++ b/src/FromCode/CodeToView.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Reflection;
 using Basic.Reference.Assemblies;
 using Microsoft.CodeAnalysis;
@@ -147,7 +147,11 @@ public class CodeToView
         var dd = typeof(Enumerable).GetTypeInfo().Assembly.Location;
         var coreDir = Directory.GetParent(dd) ?? throw new Exception($"Could not find parent directory of dotnet sdk.  Sdk directory was {dd}");
 
-        var references = new List<MetadataReference>(Net70.References.All);
+#if Building_For_Dotnet_8
+        var references = new List<MetadataReference>( Net80.References.All );
+#else
+        var references = new List<MetadataReference>( Net70.References.All );
+#endif
 
         references.Add(MetadataReference.CreateFromFile(typeof(View).Assembly.Location));
         references.Add(MetadataReference.CreateFromFile(typeof(ustring).Assembly.Location));

--- a/src/TerminalGuiDesigner.csproj
+++ b/src/TerminalGuiDesigner.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
-	<ItemGroup>
-		<AdditionalFiles Include="stylecop.json" />
-	</ItemGroup>
-	<ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="stylecop.json" />
+  </ItemGroup>
+  <ItemGroup>
     <None Include=".\logo.png">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
@@ -14,11 +14,10 @@
   </ItemGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-	<GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>TerminalGuiDesigner</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <PackageId>TerminalGuiDesigner</PackageId>
     <Version>1.0.25</Version>
@@ -126,17 +125,17 @@
 	 * Added progress indicator for creating new Views
 	 * Fixed mouse dragging/resizing of views in subviews (e.g. TabViews)
 	</PackageReleaseNotes>
+    <Configurations>Debug;Release;Debug-net8.0;Release-net8.0</Configurations>
   </PropertyGroup>
-	<ItemGroup>
-		<Content Include="NLog.config">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="Keys.yaml">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-	</ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Basic.Reference.Assemblies.Net70" Version="1.4.5" />
+    <Content Include="NLog.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Keys.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
     <PackageReference Include="nlog" Version="5.2.3" />
@@ -144,9 +143,29 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.CodeDom" Version="7.0.0" />
     <PackageReference Include="Terminal.gui" Version="1.14.0" />
     <PackageReference Include="YamlDotNet" Version="13.3.1" />
   </ItemGroup>
 
+  <Choose>
+    <When Condition="'$(Configuration)'=='Debug-net8.0' Or '$(Configuration)'=='Release-net8.0'">
+      <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <DefineConstants>$(DefineConstants);Building_For_Dotnet_8</DefineConstants>
+      </PropertyGroup>
+      <ItemGroup>
+        <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.4.5" />
+        <PackageReference Include="System.CodeDom" Version="8.0.0" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+      </PropertyGroup>
+      <ItemGroup>
+        <PackageReference Include="Basic.Reference.Assemblies.Net70" Version="1.4.5" />
+        <PackageReference Include="System.CodeDom" Version="7.0.0" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
 </Project>

--- a/src/TerminalGuiDesigner.sln
+++ b/src/TerminalGuiDesigner.sln
@@ -19,17 +19,27 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug-net8.0|Any CPU = Debug-net8.0|Any CPU
 		Release|Any CPU = Release|Any CPU
+		Release-net8.0|Any CPU = Release-net8.0|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{93CDA720-AEC9-4FE2-A1CB-AF62CE6BEFA6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{93CDA720-AEC9-4FE2-A1CB-AF62CE6BEFA6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93CDA720-AEC9-4FE2-A1CB-AF62CE6BEFA6}.Debug-net8.0|Any CPU.ActiveCfg = Debug-net8.0|Any CPU
+		{93CDA720-AEC9-4FE2-A1CB-AF62CE6BEFA6}.Debug-net8.0|Any CPU.Build.0 = Debug-net8.0|Any CPU
 		{93CDA720-AEC9-4FE2-A1CB-AF62CE6BEFA6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{93CDA720-AEC9-4FE2-A1CB-AF62CE6BEFA6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93CDA720-AEC9-4FE2-A1CB-AF62CE6BEFA6}.Release-net8.0|Any CPU.ActiveCfg = Release-net8.0|Any CPU
+		{93CDA720-AEC9-4FE2-A1CB-AF62CE6BEFA6}.Release-net8.0|Any CPU.Build.0 = Release-net8.0|Any CPU
 		{A207B4E2-4821-4710-A0C2-25236DE7FE99}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A207B4E2-4821-4710-A0C2-25236DE7FE99}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A207B4E2-4821-4710-A0C2-25236DE7FE99}.Debug-net8.0|Any CPU.ActiveCfg = Debug-net8.0|Any CPU
+		{A207B4E2-4821-4710-A0C2-25236DE7FE99}.Debug-net8.0|Any CPU.Build.0 = Debug-net8.0|Any CPU
 		{A207B4E2-4821-4710-A0C2-25236DE7FE99}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A207B4E2-4821-4710-A0C2-25236DE7FE99}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A207B4E2-4821-4710-A0C2-25236DE7FE99}.Release-net8.0|Any CPU.ActiveCfg = Release-net8.0|Any CPU
+		{A207B4E2-4821-4710-A0C2-25236DE7FE99}.Release-net8.0|Any CPU.Build.0 = Release-net8.0|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tests/UnitTests.csproj
+++ b/tests/UnitTests.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Configurations>Debug;Release;Debug-net8.0;Release-net8.0</Configurations>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,8 +19,20 @@
 	  </PackageReference>
   </ItemGroup>
 
+  <Choose>
+    <When Condition="'$(Configuration)'=='Debug-net8.0' Or '$(Configuration)'=='Release-net8.0'">
+      <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
   <ItemGroup>
     <ProjectReference Include="..\src\TerminalGuiDesigner.csproj" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Added build configurations for .net 8.0.
If one of the two -net8.0 configurations is selected, framework target and relevant dependencies are switched to 8.0. Otherwise, the old values are used.

Addresses #254 