### PR TITLE
Migrate to nunit 4

### DIFF
--- a/tests/AddViewTests.cs
+++ b/tests/AddViewTests.cs
@@ -14,6 +14,7 @@ namespace UnitTests;
 /// <summary>
 /// Tests for adding Views to other Views either with <see cref="AddViewOperation"/> or directly.
 /// </summary>
+[TestFixture]
 internal class AddViewTests : Tests
 {
     [Test]
@@ -29,17 +30,17 @@ internal class AddViewTests : Tests
         var op = new AddViewOperation(lbl, designOut, "label1");
 
         OperationManager.Instance.Do(op);
-        Assert.AreEqual(1, designOut.View.GetActualSubviews().OfType<Label>().Count());
+        Assert.That( designOut.View.GetActualSubviews().OfType<Label>().Count(), Is.EqualTo( 1 ) );
 
         OperationManager.Instance.Undo();
-        Assert.AreEqual(0, designOut.View.GetActualSubviews().OfType<Label>().Count());
+        Assert.That( designOut.View.GetActualSubviews().OfType<Label>().Count(), Is.Zero );
 
         viewToCode.GenerateDesignerCs(designOut, typeof(Dialog));
 
         var codeToView = new CodeToView(designOut.SourceCode);
         var designBackIn = codeToView.CreateInstance();
 
-        Assert.AreEqual(0, designBackIn.View.GetActualSubviews().OfType<Label>().Count());
+        Assert.That( designBackIn.View.GetActualSubviews().OfType<Label>().Count(), Is.Zero );
     }
 
     [Test]
@@ -67,7 +68,7 @@ internal class AddViewTests : Tests
 
         var lblIn = designBackIn.View.GetActualSubviews().OfType<Label>().Single();
 
-        Assert.AreEqual(lblOut.Text, lblIn.Text);
+        Assert.That(lblOut.Text, Is.EqualTo(lblIn.Text));
     }
 
     /// <summary>
@@ -89,15 +90,18 @@ internal class AddViewTests : Tests
             lbl.X = offset == null ? Pos.Percent(60) : offset.Value ? Pos.Percent(60) + 1 : Pos.Percent(60) - 1;
         }, out var lblOut);
 
-        Assert.AreEqual(lblOut.Text, lblIn.Text);
+        Assert.That(lblOut.Text, Is.EqualTo(lblIn.Text));
 
         lblIn.Width.GetDimType(out var outDimType, out var outDimValue, out var outDimOffset);
         lblIn.X.GetPosType(new List<Design>(), out var outPosType, out var outPosValue, out var outPosOffset, out _, out _);
 
-        Assert.AreEqual(DimType.Percent, outDimType);
-        Assert.Less(Math.Abs(60f - outDimValue), 0.0001);
+        Assert.Multiple( ( ) =>
+        {
+            Assert.That(outDimType, Is.EqualTo( DimType.Percent));
+            Assert.That(60f - outDimValue, Is.Zero.Within( 0.0001f ));
 
-        Assert.AreEqual(PosType.Percent, outPosType);
-        Assert.Less(Math.Abs(60f - outPosValue), 0.0001);
+            Assert.That(outPosType, Is.EqualTo(PosType.Percent));
+            Assert.That(60f - outPosValue, Is.Zero.Within( 0.0001f ));
+        } );
     }
 }

--- a/tests/ColorSchemeTests.cs
+++ b/tests/ColorSchemeTests.cs
@@ -22,9 +22,9 @@ internal class ColorSchemeTests : Tests
 
         var state = Application.Begin(window);
 
-        Assert.AreSame(Colors.Base, d.View.ColorScheme);
-        Assert.IsNotNull(d.View.ColorScheme);
-        Assert.IsFalse(d.HasKnownColorScheme());
+        ClassicAssert.AreSame(Colors.Base, d.View.ColorScheme);
+        ClassicAssert.IsNotNull(d.View.ColorScheme);
+        ClassicAssert.IsFalse(d.HasKnownColorScheme());
 
         var scheme = new ColorScheme();
         var prop = new SetPropertyOperation(d, d.GetDesignableProperty(nameof(View.ColorScheme))
@@ -33,7 +33,7 @@ internal class ColorSchemeTests : Tests
         prop.Do();
 
         // we still don't know about this scheme yet
-        Assert.IsFalse(d.HasKnownColorScheme());
+        ClassicAssert.IsFalse(d.HasKnownColorScheme());
 
         ColorSchemeManager.Instance.AddOrUpdateScheme("fff", scheme, d);
 
@@ -43,7 +43,7 @@ internal class ColorSchemeTests : Tests
         }
 
         // now we know about it
-        Assert.IsTrue(d.HasKnownColorScheme());
+        ClassicAssert.IsTrue(d.HasKnownColorScheme());
 
         ColorSchemeManager.Instance.Clear();
 
@@ -60,9 +60,9 @@ internal class ColorSchemeTests : Tests
 
         var d = new Design(new SourceCodeFile(new FileInfo("TestTrackingColorSchemes.cs")), Design.RootDesignName, view);
 
-        Assert.AreEqual(0, mgr.Schemes.Count);
+        ClassicAssert.AreEqual(0, mgr.Schemes.Count);
         mgr.FindDeclaredColorSchemes(d);
-        Assert.AreEqual(2, mgr.Schemes.Count);
+        ClassicAssert.AreEqual(2, mgr.Schemes.Count);
 
         var found = mgr.GetNameForColorScheme(new ColorScheme
         {
@@ -70,8 +70,8 @@ internal class ColorSchemeTests : Tests
             Focus = new Attribute(Color.Cyan, Color.Black),
         });
 
-        Assert.IsNotNull(found);
-        Assert.AreEqual("aaa", found);
+        ClassicAssert.IsNotNull(found);
+        ClassicAssert.AreEqual("aaa", found);
         mgr.Clear();
     }
 
@@ -90,7 +90,7 @@ internal class ColorSchemeTests : Tests
 
         var p = (ColorSchemeProperty)(btnDesign.GetDesignableProperty(nameof(View.ColorScheme)) ?? throw new Exception("Expected this not to be null"));
 
-        Assert.AreEqual("ColorScheme:(Inherited)", p.ToString());
+        ClassicAssert.AreEqual("ColorScheme:(Inherited)", p.ToString());
 
         // Define a new color scheme
         var mgr = ColorSchemeManager.Instance;
@@ -105,7 +105,7 @@ internal class ColorSchemeTests : Tests
         mgr.AddOrUpdateScheme("pink", pink, btnDesign);
 
         p.SetValue(pink);
-        Assert.AreEqual("ColorScheme:pink", p.ToString());
+        ClassicAssert.AreEqual("ColorScheme:pink", p.ToString());
 
         // when multiselecting (with a selection box) a bunch of views
         // all the views turn to green.  But we shouldn't loose track
@@ -121,15 +121,15 @@ internal class ColorSchemeTests : Tests
             selection.SetSelection(p.Design);
             selection.Clear();
 
-            Assert.AreEqual(pink, p.Design.View.ColorScheme);
+            ClassicAssert.AreEqual(pink, p.Design.View.ColorScheme);
         }
 
         selection.SetSelection(p.Design);
-        Assert.AreNotEqual(pink, p.Design.View.ColorScheme, "Expected view to be selected so be green not pink");
-        Assert.AreEqual("ColorScheme:pink", p.ToString(), "Expected us to know it was pink under the hood even while selected");
+        ClassicAssert.AreNotEqual(pink, p.Design.View.ColorScheme, "Expected view to be selected so be green not pink");
+        ClassicAssert.AreEqual("ColorScheme:pink", p.ToString(), "Expected us to know it was pink under the hood even while selected");
         selection.Clear();
 
-        Assert.AreEqual(pink, p.Design.View.ColorScheme);
+        ClassicAssert.AreEqual(pink, p.Design.View.ColorScheme);
     }
 
     [Test]
@@ -140,7 +140,7 @@ internal class ColorSchemeTests : Tests
         var v = this.Get10By10View();
         var p = (ColorSchemeProperty)(v.GetDesignableProperty(nameof(View.ColorScheme)) ?? throw new Exception("Expected this not to be null"));
 
-        Assert.AreEqual("ColorScheme:(Inherited)", p.ToString());
+        ClassicAssert.AreEqual("ColorScheme:(Inherited)", p.ToString());
 
         // Define a new color scheme
         var mgr = ColorSchemeManager.Instance;
@@ -158,10 +158,10 @@ internal class ColorSchemeTests : Tests
         SelectionManager.Instance.SetSelection(p.Design);
 
         p.SetValue(pink);
-        Assert.AreEqual("ColorScheme:pink", p.ToString());
+        ClassicAssert.AreEqual("ColorScheme:pink", p.ToString());
 
         SelectionManager.Instance.Clear();
-        Assert.AreEqual("ColorScheme:pink", p.ToString(), "Expected clearing selection not to reset an old scheme");
+        ClassicAssert.AreEqual("ColorScheme:pink", p.ToString(), "Expected clearing selection not to reset an old scheme");
     }
 
     /// <summary>
@@ -196,19 +196,19 @@ internal class ColorSchemeTests : Tests
 
             if (multiSelectBeforeSaving)
             {
-                Assert.AreEqual(mgr.Schemes.Single().Scheme, l.ColorScheme);
+                ClassicAssert.AreEqual(mgr.Schemes.Single().Scheme, l.ColorScheme);
                 SelectionManager.Instance.SetSelection((Design)l.Data);
-                Assert.AreNotEqual(mgr.Schemes.Single().Scheme, l.ColorScheme, "Expected multi selecting the view to change its color to the selected color");
+                ClassicAssert.AreNotEqual(mgr.Schemes.Single().Scheme, l.ColorScheme, "Expected multi selecting the view to change its color to the selected color");
             }
         }, out _);
 
         var lblDesignIn = (Design)lblIn.Data;
-        Assert.IsTrue(lblDesignIn.HasKnownColorScheme());
+        ClassicAssert.IsTrue(lblDesignIn.HasKnownColorScheme());
 
         // clear the selection before we do the comparison
         SelectionManager.Instance.Clear();
 
-        Assert.AreEqual("pink", mgr.GetNameForColorScheme(lblDesignIn.View.ColorScheme));
+        ClassicAssert.AreEqual("pink", mgr.GetNameForColorScheme(lblDesignIn.View.ColorScheme));
 
         mgr.Clear();
     }
@@ -218,9 +218,9 @@ internal class ColorSchemeTests : Tests
     {
         var d = new DefaultColorSchemes();
 
-        Assert.Contains(d.GreenOnBlack, d.GetDefaultSchemes().ToArray());
-        Assert.Contains(d.RedOnBlack, d.GetDefaultSchemes().ToArray());
-        Assert.Contains(d.BlueOnBlack, d.GetDefaultSchemes().ToArray());
+        ClassicAssert.Contains(d.GreenOnBlack, d.GetDefaultSchemes().ToArray());
+        ClassicAssert.Contains(d.RedOnBlack, d.GetDefaultSchemes().ToArray());
+        ClassicAssert.Contains(d.BlueOnBlack, d.GetDefaultSchemes().ToArray());
     }
 
     [TestCase(true)]
@@ -234,11 +234,11 @@ internal class ColorSchemeTests : Tests
             {
                 // Clear known default colors
                 ColorSchemeManager.Instance.Clear();
-                Assert.IsEmpty(ColorSchemeManager.Instance.Schemes);
+                ClassicAssert.IsEmpty(ColorSchemeManager.Instance.Schemes);
 
                 // Add a new color for our Label
                 ColorSchemeManager.Instance.AddOrUpdateScheme("yarg", scheme, d.GetRootDesign());
-                Assert.AreEqual(1, ColorSchemeManager.Instance.Schemes.Count);
+                ClassicAssert.AreEqual(1, ColorSchemeManager.Instance.Schemes.Count);
 
                 // Assign the new color to the view
                 var prop = new SetPropertyOperation(d, new ColorSchemeProperty(d), null, scheme);
@@ -259,9 +259,9 @@ internal class ColorSchemeTests : Tests
 
         ColorSchemeManager.Instance.Clear();
         ColorSchemeManager.Instance.FindDeclaredColorSchemes(lblInDesign.GetRootDesign());
-        Assert.AreEqual(1, ColorSchemeManager.Instance.Schemes.Count, "Reloading the view should find the explicitly declared scheme 'yarg'");
+        ClassicAssert.AreEqual(1, ColorSchemeManager.Instance.Schemes.Count, "Reloading the view should find the explicitly declared scheme 'yarg'");
 
-        Assert.AreEqual(
+        ClassicAssert.AreEqual(
             "yarg",
 
             ColorSchemeManager.Instance.GetNameForColorScheme(
@@ -272,15 +272,15 @@ internal class ColorSchemeTests : Tests
         // make a change to the yarg scheme (e.g. if user opened the color designer and made some changes)
         ColorSchemeManager.Instance.AddOrUpdateScheme("yarg", new ColorScheme { Normal = new Attribute(Color.Cyan, Color.BrightBlue) }, lblInDesign.GetRootDesign());
 
-        Assert.AreEqual(
+        ClassicAssert.AreEqual(
             "yarg",
             ColorSchemeManager.Instance.GetNameForColorScheme(
             (withSelection ? lblInDesign.State.OriginalScheme : lblIn.GetExplicitColorScheme())
             ?? throw new Exception("Expected lblIn to have an explicit ColorScheme")),
             "Expected designer to still know the name of lblIn ColorScheme");
 
-        Assert.AreEqual(Color.Cyan, lblIn.ColorScheme.Normal.Foreground, "Expected Label to be updated with the new color after being changed in designer");
-        Assert.AreEqual(Color.Cyan, lblInDesign.State.OriginalScheme?.Normal.Foreground, "Expected Label Design to also be updated with the new color");
+        ClassicAssert.AreEqual(Color.Cyan, lblIn.ColorScheme.Normal.Foreground, "Expected Label to be updated with the new color after being changed in designer");
+        ClassicAssert.AreEqual(Color.Cyan, lblInDesign.State.OriginalScheme?.Normal.Foreground, "Expected Label Design to also be updated with the new color");
     }
 
     class TestClass : View

--- a/tests/CopyPasteTests.cs
+++ b/tests/CopyPasteTests.cs
@@ -20,10 +20,10 @@ internal class CopyPasteTests : Tests
         var top = new Toplevel();
         top.Add(d.View);
 
-        Assert.IsTrue(d.IsRoot);
+        ClassicAssert.IsTrue(d.IsRoot);
         var copy = new CopyOperation(d);
 
-        Assert.IsTrue(copy.IsImpossible);
+        ClassicAssert.IsTrue(copy.IsImpossible);
     }
 
     [Test]
@@ -33,16 +33,16 @@ internal class CopyPasteTests : Tests
 
         var tv = (TableView)new ViewFactory().Create(typeof(TableView));
 
-        Assert.IsTrue(
+        ClassicAssert.IsTrue(
             new AddViewOperation(tv, d, "mytbl").Do());
 
         var tvDesign = (Design)tv.Data;
 
-        Assert.IsFalse(
+        ClassicAssert.IsFalse(
             tv.Style.InvertSelectedCellFirstCharacter,
             "Expected default state for this flag to be false");
 
-        Assert.IsFalse(
+        ClassicAssert.IsFalse(
             tv.FullRowSelect,
             "Expected default state for this flag to be false");
 
@@ -63,20 +63,20 @@ internal class CopyPasteTests : Tests
         var copy = new CopyOperation(tvDesign);
         OperationManager.Instance.Do(copy);
 
-        Assert.AreEqual(0, OperationManager.Instance.UndoStackSize,
+        ClassicAssert.AreEqual(0, OperationManager.Instance.UndoStackSize,
             "Since you cannot Undo a Copy we expected undo stack to be empty");
 
         selectionManager.Clear();
 
-        Assert.IsEmpty(selectionManager.Selected);
+        ClassicAssert.IsEmpty(selectionManager.Selected);
 
         var paste = new PasteOperation(d);
         OperationManager.Instance.Do(paste);
 
-        Assert.AreEqual(1, OperationManager.Instance.UndoStackSize,
+        ClassicAssert.AreEqual(1, OperationManager.Instance.UndoStackSize,
             "Undo stack should contain the paste operation");
 
-        Assert.IsNotEmpty(
+        ClassicAssert.IsNotEmpty(
             selectionManager.Selected,
             "After pasting, the new clone should be selected");
 
@@ -84,18 +84,18 @@ internal class CopyPasteTests : Tests
         var tv2 = (TableView)tv2Design.View;
 
         // The cloned table style/properties should match the copied ones
-        Assert.IsTrue(tv2.Style.InvertSelectedCellFirstCharacter);
-        Assert.IsTrue(tv2.FullRowSelect);
+        ClassicAssert.IsTrue(tv2.Style.InvertSelectedCellFirstCharacter);
+        ClassicAssert.IsTrue(tv2.FullRowSelect);
 
         // The cloned table columns should match the copied ones
-        Assert.AreEqual(2, tv2.Table.Columns.Count);
-        Assert.AreEqual(0, tv2.Table.Rows.Count);
-        Assert.AreEqual("Yarg", tv2.Table.Columns[0].ColumnName);
-        Assert.AreEqual("Blerg", tv2.Table.Columns[1].ColumnName);
-        Assert.AreEqual(typeof(int), tv2.Table.Columns[0].DataType);
-        Assert.AreEqual(typeof(DateTime), tv2.Table.Columns[1].DataType);
+        ClassicAssert.AreEqual(2, tv2.Table.Columns.Count);
+        ClassicAssert.AreEqual(0, tv2.Table.Rows.Count);
+        ClassicAssert.AreEqual("Yarg", tv2.Table.Columns[0].ColumnName);
+        ClassicAssert.AreEqual("Blerg", tv2.Table.Columns[1].ColumnName);
+        ClassicAssert.AreEqual(typeof(int), tv2.Table.Columns[0].DataType);
+        ClassicAssert.AreEqual(typeof(DateTime), tv2.Table.Columns[1].DataType);
 
-        Assert.AreNotSame(tv.Table, tv2.Table,
+        ClassicAssert.AreNotSame(tv.Table, tv2.Table,
             "Cloned table should be a new table not a reference to the old one");
     }
 
@@ -121,27 +121,27 @@ internal class CopyPasteTests : Tests
         new CopyOperation(SelectionManager.Instance.Selected.ToArray()).Do();
         var cmd = new PasteOperation(d);
 
-        Assert.IsFalse(cmd.IsImpossible);
+        ClassicAssert.IsFalse(cmd.IsImpossible);
         OperationManager.Instance.Do(cmd);
 
         // (Root + 2 original + 2 cloned)
-        Assert.AreEqual(5, d.GetAllDesigns().Count());
+        ClassicAssert.AreEqual(5, d.GetAllDesigns().Count());
 
         var cloneLabelDesign = selected.Selected.ElementAt(0);
         var cloneTextFieldDesign = selected.Selected.ElementAt(1);
 
-        Assert.IsInstanceOf(typeof(Label), cloneLabelDesign.View);
-        Assert.IsInstanceOf(typeof(TextField), cloneTextFieldDesign.View);
+        ClassicAssert.IsInstanceOf(typeof(Label), cloneLabelDesign.View);
+        ClassicAssert.IsInstanceOf(typeof(TextField), cloneTextFieldDesign.View);
 
         cloneTextFieldDesign.View.X.GetPosType(
             d.GetAllDesigns().ToArray(),
             out var posType, out _, out var relativeTo, out var side, out var offset);
 
-        Assert.AreEqual(PosType.Relative, posType);
-        Assert.AreEqual(1, offset);
-        Assert.AreEqual(Side.Right, side);
+        ClassicAssert.AreEqual(PosType.Relative, posType);
+        ClassicAssert.AreEqual(1, offset);
+        ClassicAssert.AreEqual(Side.Right, side);
 
-        Assert.AreSame(cloneLabelDesign, relativeTo, "Pasted clone should be relative to the also pasted label");
+        ClassicAssert.AreSame(cloneLabelDesign, relativeTo, "Pasted clone should be relative to the also pasted label");
     }
 
     /// <summary>
@@ -171,24 +171,24 @@ internal class CopyPasteTests : Tests
 
         var cmd = new PasteOperation(d);
 
-        Assert.IsFalse(cmd.IsImpossible);
+        ClassicAssert.IsFalse(cmd.IsImpossible);
         OperationManager.Instance.Do(cmd);
 
         // (Root + 2 original + 1 cloned)
-        Assert.AreEqual(4, d.GetAllDesigns().Count());
+        ClassicAssert.AreEqual(4, d.GetAllDesigns().Count());
 
         var cloneTextFieldDesign = selected.Selected.ElementAt(0);
-        Assert.IsInstanceOf(typeof(TextField), cloneTextFieldDesign.View);
+        ClassicAssert.IsInstanceOf(typeof(TextField), cloneTextFieldDesign.View);
 
         cloneTextFieldDesign.View.X.GetPosType(
             d.GetAllDesigns().ToArray(),
             out var posType, out _, out var relativeTo, out var side, out var offset);
 
-        Assert.AreEqual(PosType.Relative, posType);
-        Assert.AreEqual(1, offset);
-        Assert.AreEqual(Side.Right, side);
+        ClassicAssert.AreEqual(PosType.Relative, posType);
+        ClassicAssert.AreEqual(1, offset);
+        ClassicAssert.AreEqual(Side.Right, side);
 
-        Assert.AreSame(lbl.Data, relativeTo, "Pasted clone should be relative to the original label");
+        ClassicAssert.AreSame(lbl.Data, relativeTo, "Pasted clone should be relative to the original label");
     }
 
     [Test]
@@ -212,14 +212,14 @@ internal class CopyPasteTests : Tests
         dtb.GetDesignableProperty(nameof(ColorScheme))?.SetValue(green);
         d.View.ColorScheme = green;
 
-        Assert.AreEqual(lbl.ColorScheme, green, "The label should inherit color scheme from the parent");
+        ClassicAssert.AreEqual(lbl.ColorScheme, green, "The label should inherit color scheme from the parent");
 
-        Assert.AreEqual(
+        ClassicAssert.AreEqual(
             "ColorScheme:(Inherited)",
             dlbl.GetDesignableProperties().OfType<ColorSchemeProperty>().Single().ToString(),
             "Expected ColorScheme to be known to be inherited");
 
-        Assert.AreEqual(
+        ClassicAssert.AreEqual(
             "ColorScheme:green",
             dtb.GetDesignableProperties().OfType<ColorSchemeProperty>().Single().ToString(),
             "TextBox inherits but also is explicitly marked as green");
@@ -231,7 +231,7 @@ internal class CopyPasteTests : Tests
         OperationManager.Instance.Do(new PasteOperation(d));
 
         // (Root + 2 original + 2 cloned)
-        Assert.AreEqual(5, d.GetAllDesigns().Count());
+        ClassicAssert.AreEqual(5, d.GetAllDesigns().Count());
 
         var dlbl2 = d.GetAllDesigns().Single(d => d.FieldName == "lbl2");
         var dtb2 = d.GetAllDesigns().Single(d => d.FieldName == "tb2");
@@ -239,15 +239,15 @@ internal class CopyPasteTests : Tests
         // clear whatever the current selection is (probably the pasted views)
         SelectionManager.Instance.Clear();
 
-        Assert.AreEqual(dlbl2.View.ColorScheme, green, "The newly pasted label should also inherit color scheme from the parent");
+        ClassicAssert.AreEqual(dlbl2.View.ColorScheme, green, "The newly pasted label should also inherit color scheme from the parent");
 
         // but be known to inherit
-        Assert.AreEqual(
+        ClassicAssert.AreEqual(
             "ColorScheme:(Inherited)",
             dlbl2.GetDesignableProperties().OfType<ColorSchemeProperty>().Single().ToString(),
             "Expected ColorScheme to be known to be inherited");
 
-        Assert.AreEqual(
+        ClassicAssert.AreEqual(
             "ColorScheme:green",
             dtb2.GetDesignableProperties().OfType<ColorSchemeProperty>().Single().ToString(),
             "TextBox2 should have its copy pasted explicitly marked green");
@@ -263,14 +263,14 @@ internal class CopyPasteTests : Tests
                 new AddViewOperation(new Label(), d, "lbl1").Do();
                 new AddViewOperation(new Label(), d, "lbl2").Do();
                 
-                Assert.AreEqual(2,v.GetActualSubviews().Count(), "Expected the FrameView to have 2 children (lbl1 and lbl2)");
+                ClassicAssert.AreEqual(2,v.GetActualSubviews().Count(), "Expected the FrameView to have 2 children (lbl1 and lbl2)");
 
                 Design[] toCopy;
 
                 if(alsoSelectSubElements)
                 {
                     var lbl1Design = (Design)d.View.GetActualSubviews().First().Data;
-                    Assert.AreEqual("lbl1", lbl1Design.FieldName);
+                    ClassicAssert.AreEqual("lbl1", lbl1Design.FieldName);
 
                     toCopy = new Design[] { d, lbl1Design};
                 }
@@ -284,15 +284,15 @@ internal class CopyPasteTests : Tests
 
                 var rootDesign = d.GetRootDesign();
 
-                Assert.IsTrue(new PasteOperation(rootDesign).Do());
+                ClassicAssert.IsTrue(new PasteOperation(rootDesign).Do());
 
                 var rootSubviews = rootDesign.View.GetActualSubviews();
 
-                Assert.AreEqual(2, rootSubviews.Count, "Expected root to have 2 FrameView now");
-                Assert.IsTrue(rootSubviews.All(v => v is FrameView));
+                ClassicAssert.AreEqual(2, rootSubviews.Count, "Expected root to have 2 FrameView now");
+                ClassicAssert.IsTrue(rootSubviews.All(v => v is FrameView));
 
 
-                Assert.IsTrue(
+                ClassicAssert.IsTrue(
                     rootSubviews.All(f => f.GetActualSubviews().Count() == 2),
                     "Expected both FrameView (copied and pasted) to have the full contents of 2 Labels");
             }
@@ -311,12 +311,12 @@ internal class CopyPasteTests : Tests
 
                 var rootDesign = d.GetRootDesign();
 
-                Assert.IsTrue(new PasteOperation(rootDesign).Do());
+                ClassicAssert.IsTrue(new PasteOperation(rootDesign).Do());
 
                 var rootSubviews = rootDesign.View.GetActualSubviews();
 
-                Assert.AreEqual(2, rootSubviews.Count, "Expected root to have 2 ScrollView now");
-                Assert.IsTrue(rootSubviews.All(v => v is ScrollView));
+                ClassicAssert.AreEqual(2, rootSubviews.Count, "Expected root to have 2 ScrollView now");
+                ClassicAssert.IsTrue(rootSubviews.All(v => v is ScrollView));
             }
             , out _
             );
@@ -332,12 +332,12 @@ internal class CopyPasteTests : Tests
 
                 var rootDesign = d.GetRootDesign();
 
-                Assert.IsTrue(new PasteOperation(d).Do());
+                ClassicAssert.IsTrue(new PasteOperation(d).Do());
 
                 var rootSubviews = rootDesign.View.GetActualSubviews();
 
-                Assert.AreEqual(2, rootSubviews.Count, "Expected root to have 2 ScrollView now");
-                Assert.IsTrue(rootSubviews.All(v => v is ScrollView));
+                ClassicAssert.AreEqual(2, rootSubviews.Count, "Expected root to have 2 ScrollView now");
+                ClassicAssert.IsTrue(rootSubviews.All(v => v is ScrollView));
             }
             , out _
             );
@@ -362,34 +362,34 @@ internal class CopyPasteTests : Tests
                 new AddViewOperation(new Label("lbl5"), d, "lbl5").Do();
                 new AddViewOperation(new Label("lbl6"), d, "lbl6").Do();
 
-                Assert.AreEqual(3, v.Tabs.Count);
-                Assert.AreEqual(2, v.Tabs.ElementAt(0).View.GetActualSubviews().Count);
-                Assert.AreEqual(2, v.Tabs.ElementAt(1).View.GetActualSubviews().Count);
-                Assert.AreEqual(2, v.Tabs.ElementAt(2).View.GetActualSubviews().Count);
+                ClassicAssert.AreEqual(3, v.Tabs.Count);
+                ClassicAssert.AreEqual(2, v.Tabs.ElementAt(0).View.GetActualSubviews().Count);
+                ClassicAssert.AreEqual(2, v.Tabs.ElementAt(1).View.GetActualSubviews().Count);
+                ClassicAssert.AreEqual(2, v.Tabs.ElementAt(2).View.GetActualSubviews().Count);
 
                 // copy the TabView
                 new CopyOperation(d).Do();
 
                 var rootDesign = d.GetRootDesign();
-                Assert.IsTrue(new PasteOperation(rootDesign).Do());
+                ClassicAssert.IsTrue(new PasteOperation(rootDesign).Do());
 
                 var rootSubviews = rootDesign.View.GetActualSubviews();
 
-                Assert.AreEqual(2, rootSubviews.Count, "Expected root to have 2 TabView now");
-                Assert.IsTrue(rootSubviews.All(v => v is TabView));
+                ClassicAssert.AreEqual(2, rootSubviews.Count, "Expected root to have 2 TabView now");
+                ClassicAssert.IsTrue(rootSubviews.All(v => v is TabView));
 
                 var orig = (TabView)rootSubviews[0];
                 var pasted = (TabView)rootSubviews[1];
 
-                Assert.AreEqual(3, orig.Tabs.Count);
-                Assert.AreEqual(2, orig.Tabs.ElementAt(0).View.GetActualSubviews().Count);
-                Assert.AreEqual(2, orig.Tabs.ElementAt(1).View.GetActualSubviews().Count);
-                Assert.AreEqual(2, orig.Tabs.ElementAt(2).View.GetActualSubviews().Count);
+                ClassicAssert.AreEqual(3, orig.Tabs.Count);
+                ClassicAssert.AreEqual(2, orig.Tabs.ElementAt(0).View.GetActualSubviews().Count);
+                ClassicAssert.AreEqual(2, orig.Tabs.ElementAt(1).View.GetActualSubviews().Count);
+                ClassicAssert.AreEqual(2, orig.Tabs.ElementAt(2).View.GetActualSubviews().Count);
 
-                Assert.AreEqual(3, pasted.Tabs.Count);
-                Assert.AreEqual(2, pasted.Tabs.ElementAt(0).View.GetActualSubviews().Count);
-                Assert.AreEqual(2, pasted.Tabs.ElementAt(1).View.GetActualSubviews().Count);
-                Assert.AreEqual(2, pasted.Tabs.ElementAt(2).View.GetActualSubviews().Count);
+                ClassicAssert.AreEqual(3, pasted.Tabs.Count);
+                ClassicAssert.AreEqual(2, pasted.Tabs.ElementAt(0).View.GetActualSubviews().Count);
+                ClassicAssert.AreEqual(2, pasted.Tabs.ElementAt(1).View.GetActualSubviews().Count);
+                ClassicAssert.AreEqual(2, pasted.Tabs.ElementAt(2).View.GetActualSubviews().Count);
             }
             , out _
             );

--- a/tests/DimTests.cs
+++ b/tests/DimTests.cs
@@ -8,66 +8,66 @@ internal class DimTests
     [Test]
     public void TestIsAbsolute()
     {
-        Assert.IsTrue(Dim.Sized(50).IsAbsolute());
+        ClassicAssert.IsTrue(Dim.Sized(50).IsAbsolute());
         this.AssertIsNotPercent(Dim.Sized(50));
-        Assert.IsFalse(Dim.Sized(50).IsFill());
+        ClassicAssert.IsFalse(Dim.Sized(50).IsFill());
 
-        Assert.IsTrue(Dim.Sized(50).IsAbsolute(out int size));
-        Assert.AreEqual(50, size);
+        ClassicAssert.IsTrue(Dim.Sized(50).IsAbsolute(out int size));
+        ClassicAssert.AreEqual(50, size);
 
-        Assert.IsTrue(Dim.Sized(50).GetDimType(out var type, out var val, out var offset));
-        Assert.AreEqual(DimType.Absolute, type);
-        Assert.AreEqual(50, val);
-        Assert.AreEqual(0, offset);
+        ClassicAssert.IsTrue(Dim.Sized(50).GetDimType(out var type, out var val, out var offset));
+        ClassicAssert.AreEqual(DimType.Absolute, type);
+        ClassicAssert.AreEqual(50, val);
+        ClassicAssert.AreEqual(0, offset);
     }
 
     [Test]
     public void TestIsAbsolute_FromInt()
     {
         Dim d = 50;
-        Assert.IsTrue(d.IsAbsolute());
-        Assert.IsFalse(d.IsPercent());
-        Assert.IsFalse(d.IsFill());
+        ClassicAssert.IsTrue(d.IsAbsolute());
+        ClassicAssert.IsFalse(d.IsPercent());
+        ClassicAssert.IsFalse(d.IsFill());
 
-        Assert.IsTrue(d.IsAbsolute(out int size));
-        Assert.AreEqual(50, size);
+        ClassicAssert.IsTrue(d.IsAbsolute(out int size));
+        ClassicAssert.AreEqual(50, size);
 
-        Assert.IsTrue(d.GetDimType(out var type, out var val, out var offset));
-        Assert.AreEqual(DimType.Absolute, type);
-        Assert.AreEqual(50, val);
-        Assert.AreEqual(0, offset);
+        ClassicAssert.IsTrue(d.GetDimType(out var type, out var val, out var offset));
+        ClassicAssert.AreEqual(DimType.Absolute, type);
+        ClassicAssert.AreEqual(50, val);
+        ClassicAssert.AreEqual(0, offset);
     }
 
     [Test]
     public void TestIsPercent()
     {
-        Assert.IsFalse(Dim.Percent(24).IsAbsolute());
-        Assert.IsTrue(Dim.Percent(24).IsPercent());
-        Assert.IsFalse(Dim.Percent(24).IsFill());
+        ClassicAssert.IsFalse(Dim.Percent(24).IsAbsolute());
+        ClassicAssert.IsTrue(Dim.Percent(24).IsPercent());
+        ClassicAssert.IsFalse(Dim.Percent(24).IsFill());
 
-        Assert.IsTrue(Dim.Percent(24).IsPercent(out var size));
-        Assert.AreEqual(24f, size);
+        ClassicAssert.IsTrue(Dim.Percent(24).IsPercent(out var size));
+        ClassicAssert.AreEqual(24f, size);
 
-        Assert.IsTrue(Dim.Percent(24).GetDimType(out var type, out var val, out var offset));
-        Assert.AreEqual(DimType.Percent, type);
-        Assert.AreEqual(24, val);
-        Assert.AreEqual(0, offset);
+        ClassicAssert.IsTrue(Dim.Percent(24).GetDimType(out var type, out var val, out var offset));
+        ClassicAssert.AreEqual(DimType.Percent, type);
+        ClassicAssert.AreEqual(24, val);
+        ClassicAssert.AreEqual(0, offset);
     }
 
     [Test]
     public void TestIsFill()
     {
-        Assert.IsFalse(Dim.Fill(2).IsAbsolute());
-        Assert.IsFalse(Dim.Fill(2).IsPercent());
-        Assert.IsTrue(Dim.Fill(2).IsFill());
+        ClassicAssert.IsFalse(Dim.Fill(2).IsAbsolute());
+        ClassicAssert.IsFalse(Dim.Fill(2).IsPercent());
+        ClassicAssert.IsTrue(Dim.Fill(2).IsFill());
 
-        Assert.IsTrue(Dim.Fill(5).IsFill(out var margin));
-        Assert.AreEqual(5, margin);
+        ClassicAssert.IsTrue(Dim.Fill(5).IsFill(out var margin));
+        ClassicAssert.AreEqual(5, margin);
 
-        Assert.IsTrue(Dim.Fill(5).GetDimType(out var type, out var val, out var offset));
-        Assert.AreEqual(DimType.Fill, type);
-        Assert.AreEqual(5, val);
-        Assert.AreEqual(0, offset);
+        ClassicAssert.IsTrue(Dim.Fill(5).GetDimType(out var type, out var val, out var offset));
+        ClassicAssert.AreEqual(DimType.Fill, type);
+        ClassicAssert.AreEqual(5, val);
+        ClassicAssert.AreEqual(0, offset);
     }
 
     [Test]
@@ -75,89 +75,89 @@ internal class DimTests
     {
         var v = new View();
 
-        Assert.IsNull(v.Width, "As of v1.7.0 a new View started getting null for its Width, if this assert fails it means that behaviour was reverted and this test can be altered or suppressed");
+        ClassicAssert.IsNull(v.Width, "As of v1.7.0 a new View started getting null for its Width, if this assert fails it means that behaviour was reverted and this test can be altered or suppressed");
 
-        Assert.IsTrue(v.Width.IsAbsolute());
-        Assert.IsTrue(v.Width.IsAbsolute(out int n));
-        Assert.AreEqual(0, n);
+        ClassicAssert.IsTrue(v.Width.IsAbsolute());
+        ClassicAssert.IsTrue(v.Width.IsAbsolute(out int n));
+        ClassicAssert.AreEqual(0, n);
 
-        Assert.IsFalse(v.Width.IsFill());
-        Assert.IsFalse(v.Width.IsPercent());
-        Assert.IsFalse(v.Width.IsCombine());
+        ClassicAssert.IsFalse(v.Width.IsFill());
+        ClassicAssert.IsFalse(v.Width.IsPercent());
+        ClassicAssert.IsFalse(v.Width.IsCombine());
 
-        Assert.IsTrue(v.Width.GetDimType(out var type, out var val, out _));
+        ClassicAssert.IsTrue(v.Width.GetDimType(out var type, out var val, out _));
 
-        Assert.AreEqual(DimType.Absolute, type);
-        Assert.AreEqual(0, val);
+        ClassicAssert.AreEqual(DimType.Absolute, type);
+        ClassicAssert.AreEqual(0, val);
     }
 
     [Test]
     public void TestGetDimType_WithOffset()
     {
         var d = Dim.Percent(50) + 2;
-        Assert.True(d.GetDimType(out DimType type, out float value, out int offset), $"Could not figure out DimType for '{d}'");
-        Assert.AreEqual(DimType.Percent, type);
-        Assert.AreEqual(50, value);
-        Assert.AreEqual(2, offset);
+        ClassicAssert.True(d.GetDimType(out DimType type, out float value, out int offset), $"Could not figure out DimType for '{d}'");
+        ClassicAssert.AreEqual(DimType.Percent, type);
+        ClassicAssert.AreEqual(50, value);
+        ClassicAssert.AreEqual(2, offset);
 
         d = Dim.Percent(50) - 2;
-        Assert.True(d.GetDimType(out type, out value, out offset), $"Could not figure out DimType for '{d}'");
-        Assert.AreEqual(DimType.Percent, type);
-        Assert.AreEqual(50, value);
-        Assert.AreEqual(-2, offset);
+        ClassicAssert.True(d.GetDimType(out type, out value, out offset), $"Could not figure out DimType for '{d}'");
+        ClassicAssert.AreEqual(DimType.Percent, type);
+        ClassicAssert.AreEqual(50, value);
+        ClassicAssert.AreEqual(-2, offset);
 
         d = Dim.Fill(5) + 2;
-        Assert.True(d.GetDimType(out type, out value, out offset), $"Could not figure out DimType for '{d}'");
-        Assert.AreEqual(DimType.Fill, type);
-        Assert.AreEqual(5, value);
-        Assert.AreEqual(2, offset);
+        ClassicAssert.True(d.GetDimType(out type, out value, out offset), $"Could not figure out DimType for '{d}'");
+        ClassicAssert.AreEqual(DimType.Fill, type);
+        ClassicAssert.AreEqual(5, value);
+        ClassicAssert.AreEqual(2, offset);
 
         d = Dim.Fill(5) - 2;
-        Assert.True(d.GetDimType(out type, out value, out offset), $"Could not figure out DimType for '{d}'");
-        Assert.AreEqual(DimType.Fill, type);
-        Assert.AreEqual(5, value);
-        Assert.AreEqual(-2, offset);
+        ClassicAssert.True(d.GetDimType(out type, out value, out offset), $"Could not figure out DimType for '{d}'");
+        ClassicAssert.AreEqual(DimType.Fill, type);
+        ClassicAssert.AreEqual(5, value);
+        ClassicAssert.AreEqual(-2, offset);
     }
 
     [Test]
     public void TestGetCode_WithNoOffset()
     {
         var d = Dim.Percent(50);
-        Assert.AreEqual("Dim.Percent(50f)", d.ToCode());
+        ClassicAssert.AreEqual("Dim.Percent(50f)", d.ToCode());
 
         d = Dim.Percent(50);
-        Assert.AreEqual("Dim.Percent(50f)", d.ToCode());
+        ClassicAssert.AreEqual("Dim.Percent(50f)", d.ToCode());
 
         d = Dim.Fill(5);
-        Assert.AreEqual("Dim.Fill(5)", d.ToCode());
+        ClassicAssert.AreEqual("Dim.Fill(5)", d.ToCode());
 
         d = Dim.Fill(5);
-        Assert.AreEqual("Dim.Fill(5)", d.ToCode());
+        ClassicAssert.AreEqual("Dim.Fill(5)", d.ToCode());
     }
 
     [Test]
     public void TestGetCode_WithOffset()
     {
         var d = Dim.Percent(50) + 2;
-        Assert.AreEqual("Dim.Percent(50f) + 2", d.ToCode());
+        ClassicAssert.AreEqual("Dim.Percent(50f) + 2", d.ToCode());
 
         d = Dim.Percent(50) - 2;
-        Assert.AreEqual("Dim.Percent(50f) - 2", d.ToCode());
+        ClassicAssert.AreEqual("Dim.Percent(50f) - 2", d.ToCode());
 
         d = Dim.Fill(5) + 2;
-        Assert.AreEqual("Dim.Fill(5) + 2", d.ToCode());
+        ClassicAssert.AreEqual("Dim.Fill(5) + 2", d.ToCode());
 
         d = Dim.Fill(5) - 2;
-        Assert.AreEqual("Dim.Fill(5) - 2", d.ToCode());
+        ClassicAssert.AreEqual("Dim.Fill(5) - 2", d.ToCode());
     }
 
     private void AssertIsNotPercent(Dim dim)
     {
-        Assert.IsFalse(dim.IsPercent());
-        Assert.IsFalse(dim.IsPercent(out var percent));
-        Assert.AreEqual(0, percent);
+        ClassicAssert.IsFalse(dim.IsPercent());
+        ClassicAssert.IsFalse(dim.IsPercent(out var percent));
+        ClassicAssert.AreEqual(0, percent);
 
         dim.GetDimType(out DimType type, out _, out _);
-        Assert.AreNotEqual(DimType.Percent, type);
+        ClassicAssert.AreNotEqual(DimType.Percent, type);
     }
 }

--- a/tests/EditorTests.cs
+++ b/tests/EditorTests.cs
@@ -12,24 +12,24 @@ internal class EditorTests : Tests
     {
         var e = new Editor();
 
-        Assert.IsFalse(e.HasUnsavedChanges(), "With nothing open there should not be any unsaved changes");
+        ClassicAssert.IsFalse(e.HasUnsavedChanges(), "With nothing open there should not be any unsaved changes");
 
         OperationManager.Instance.Do(new DummyOperation());
 
-        Assert.IsTrue(e.HasUnsavedChanges(), "We have performed an operation and not yet saved");
+        ClassicAssert.IsTrue(e.HasUnsavedChanges(), "We have performed an operation and not yet saved");
 
         // fake a save
         var lastOp = OperationManager.Instance.GetLastAppliedOperation() ?? throw new Exception("Expected DummyOperation to be known as the last performed");
         var f = typeof(Editor).GetField("lastSavedOperation", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic) ?? throw new Exception("Missing field");
         f.SetValue(e, lastOp.UniqueIdentifier);
 
-        Assert.IsFalse(e.HasUnsavedChanges(), "Now that we have saved there should be no unsaved changes");
+        ClassicAssert.IsFalse(e.HasUnsavedChanges(), "Now that we have saved there should be no unsaved changes");
 
         OperationManager.Instance.Do(new DummyOperation());
-        Assert.IsTrue(e.HasUnsavedChanges(), "When we perform an operation after saving we now have changes again");
+        ClassicAssert.IsTrue(e.HasUnsavedChanges(), "When we perform an operation after saving we now have changes again");
 
         OperationManager.Instance.Undo();
-        Assert.IsFalse(e.HasUnsavedChanges(), "Undoing the newly performed operation should mean that we are back where we were when we saved (i.e. no changes)");
+        ClassicAssert.IsFalse(e.HasUnsavedChanges(), "Undoing the newly performed operation should mean that we are back where we were when we saved (i.e. no changes)");
     }
 
     class DummyOperation : Operation

--- a/tests/KeyMapTests.cs
+++ b/tests/KeyMapTests.cs
@@ -19,7 +19,7 @@ internal class KeyMapTests : Tests
         var serializer = new Serializer();
         var expected = serializer.Serialize(km);
 
-        Assert.AreEqual(
+        ClassicAssert.AreEqual(
             expected.Replace("\r\n", "\n").Trim(),
             File.ReadAllText(keys).Replace("\r\n", "\n").Trim(),
             $"The default yaml file ('Keys.yaml') that ships with TerminalGuiDesigner should match the default values in KeyMap. Set it to:{Environment.NewLine}{expected}");

--- a/tests/KeyboardManagerTests.cs
+++ b/tests/KeyboardManagerTests.cs
@@ -17,7 +17,7 @@ internal class KeyboardManagerTests : Tests
         v.Data = d;
 
         var mgr = new KeyboardManager(new KeyMap());
-        Assert.IsFalse(mgr.HandleKey(v, new KeyEvent(Key.Backspace, new KeyModifiers())));
+        ClassicAssert.IsFalse(mgr.HandleKey(v, new KeyEvent(Key.Backspace, new KeyModifiers())));
         
         Application.Top.Add(v);
         v.Redraw(v.Bounds = new Rect(0, 0, 6, 1));
@@ -41,17 +41,17 @@ internal class KeyboardManagerTests : Tests
         mgr.HandleKey(v, new KeyEvent(Key.Backspace, new KeyModifiers()));
         mgr.HandleKey(v, new KeyEvent(Key.Backspace, new KeyModifiers()));
 
-        Assert.IsTrue(string.IsNullOrWhiteSpace(v.Text.ToString()));
+        ClassicAssert.IsTrue(string.IsNullOrWhiteSpace(v.Text.ToString()));
 
         mgr.HandleKey(v, new KeyEvent(Key.B, new KeyModifiers { Shift = true }));
         mgr.HandleKey(v, new KeyEvent((Key)'a', new KeyModifiers()));
         mgr.HandleKey(v, new KeyEvent((Key)'d', new KeyModifiers()));
 
-        Assert.AreEqual("Bad", v.Text.ToString());
+        ClassicAssert.AreEqual("Bad", v.Text.ToString());
 
         mgr.HandleKey(v, new KeyEvent(Key.Backspace, new KeyModifiers()));
         mgr.HandleKey(v, new KeyEvent(Key.Backspace, new KeyModifiers()));
 
-        Assert.AreEqual("B", v.Text.ToString());
+        ClassicAssert.AreEqual("B", v.Text.ToString());
     }
 }

--- a/tests/LabelTests.cs
+++ b/tests/LabelTests.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Linq;
 using NUnit.Framework;
 using Terminal.Gui;
@@ -32,7 +32,7 @@ internal class LabelTests : Tests
         OperationManager.Instance.Redo();
         OperationManager.Instance.Redo();
 
-        Assert.AreEqual(lblDesign.View.X.ToString(), $"Pos.Factor({0.5})");
+        ClassicAssert.AreEqual(lblDesign.View.X.ToString(), $"Pos.Factor({0.5})");
     }
 
     [Test]
@@ -72,6 +72,6 @@ internal class LabelTests : Tests
         OperationManager.Instance.Redo();
         OperationManager.Instance.Undo();
 
-        Assert.AreEqual(lblDesign.View.X.ToString(), $"Pos.Factor({0.5})");
+        ClassicAssert.AreEqual(lblDesign.View.X.ToString(), $"Pos.Factor({0.5})");
     }
 }

--- a/tests/ListViewTests.cs
+++ b/tests/ListViewTests.cs
@@ -24,7 +24,7 @@ class ListViewTests : Tests
         var factory = new ViewFactory();
         var lvOut = (ListView)factory.Create(typeof(ListView));
 
-        Assert.AreEqual(3, lvOut.Source.Count);
+        ClassicAssert.AreEqual(3, lvOut.Source.Count);
 
         OperationManager.Instance.Do(new AddViewOperation(lvOut, designOut, "myList"));
 
@@ -37,7 +37,7 @@ class ListViewTests : Tests
 
         var listIn = designBackIn.View.GetActualSubviews().OfType<ListView>().Single();
 
-        Assert.AreEqual(3, listIn.Source.Count);
+        ClassicAssert.AreEqual(3, listIn.Source.Count);
     }
 
     [Test]
@@ -50,15 +50,15 @@ class ListViewTests : Tests
         var d = new Design(new SourceCodeFile(file), "lv", lv);
         var prop = d.GetDesignableProperties().Single(p => p.PropertyInfo.Name.Equals("Source"));
 
-        Assert.IsNull(lv.Source);
+        ClassicAssert.IsNull(lv.Source);
 
         prop.SetValue(new string[] { "hi there", "my friend" });
 
-        Assert.AreEqual(2, lv.Source.Count);
+        ClassicAssert.AreEqual(2, lv.Source.Count);
 
         var code = PropertyTests.ExpressionToCode(prop.GetRhs());
 
-        Assert.AreEqual(
+        ClassicAssert.AreEqual(
             "new Terminal.Gui.ListWrapper(new string[] {\n            \"hi there\",\n            \"my friend\"})".Replace("\n", Environment.NewLine),
             code);
     }

--- a/tests/MenuBarExtensionsTests.cs
+++ b/tests/MenuBarExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using Terminal.Gui;
 using TerminalGuiDesigner;
 using TerminalGuiDesigner.Operations.MenuOperations;
@@ -17,20 +17,20 @@ internal class MenuBarExtensionsTests : Tests
             // Note that this test is brittle and subject to changes in Terminal.Gui e.g. pushing menus closer together.
             v.Menus[0].Title = "test";
 
-            Assert.IsNull(v.ScreenToMenuBarItem(0),
+            ClassicAssert.IsNull(v.ScreenToMenuBarItem(0),
                 "Expected Terminal.Gui MenuBar to have 1 unit of whitespace before any MenuBarItems (e.g. File) get rendered. This may change in future, if so then update this test.");
             
             // Clicks in the "test" region
-            Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(1));
-            Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(2));
-            Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(3));
-            Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(4));
+            ClassicAssert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(1));
+            ClassicAssert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(2));
+            ClassicAssert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(3));
+            ClassicAssert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(4));
 
             // Clicks in the whitespace after "test" but before any other menus (of which there are none in this test btw)
-            Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5));
-            Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(6));
+            ClassicAssert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5));
+            ClassicAssert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(6));
 
-            Assert.IsNull(v.ScreenToMenuBarItem(7), "Expected a click here to be off the end of the Menu 'test' + 2 whitespace characters");
+            ClassicAssert.IsNull(v.ScreenToMenuBarItem(7), "Expected a click here to be off the end of the Menu 'test' + 2 whitespace characters");
         }, out _);
     }
 
@@ -47,35 +47,35 @@ internal class MenuBarExtensionsTests : Tests
             new AddMenuOperation(d, "next").Do();
             new AddMenuOperation(d, "more").Do();
 
-            Assert.IsNull(v.ScreenToMenuBarItem(0));
+            ClassicAssert.IsNull(v.ScreenToMenuBarItem(0));
 
             // Clicks in the "test" region
-            Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(1));
-            Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(2));
-            Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(3));
-            Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(4));
-            Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5));
-            Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(6));
+            ClassicAssert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(1));
+            ClassicAssert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(2));
+            ClassicAssert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(3));
+            ClassicAssert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(4));
+            ClassicAssert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5));
+            ClassicAssert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(6));
 
             // Clicks in the "next" region
-            Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(7));
-            Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(8));
-            Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(9));
-            Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(10));
-            Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(11));
-            Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(12));
+            ClassicAssert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(7));
+            ClassicAssert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(8));
+            ClassicAssert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(9));
+            ClassicAssert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(10));
+            ClassicAssert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(11));
+            ClassicAssert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(12));
 
 
             // Clicks in the "more" region
-            Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(13));
-            Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(14));
-            Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(15));
-            Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(16));
-            Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(17));
-            Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(18));
+            ClassicAssert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(13));
+            ClassicAssert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(14));
+            ClassicAssert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(15));
+            ClassicAssert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(16));
+            ClassicAssert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(17));
+            ClassicAssert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(18));
 
             // clicks off the end of the right
-            Assert.IsNull(v.ScreenToMenuBarItem(19));
+            ClassicAssert.IsNull(v.ScreenToMenuBarItem(19));
         }, out _);
     }
 
@@ -96,35 +96,35 @@ internal class MenuBarExtensionsTests : Tests
             new AddMenuOperation(d, "next").Do();
             new AddMenuOperation(d, "more").Do();
 
-            Assert.IsNull(v.ScreenToMenuBarItem(5+0));
+            ClassicAssert.IsNull(v.ScreenToMenuBarItem(5+0));
 
             // Clicks in the "test" region
-            Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5+1));
-            Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5+2));
-            Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5+3));
-            Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5+4));
-            Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5+5));
-            Assert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5+6));
+            ClassicAssert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5+1));
+            ClassicAssert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5+2));
+            ClassicAssert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5+3));
+            ClassicAssert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5+4));
+            ClassicAssert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5+5));
+            ClassicAssert.AreEqual(v.Menus[0], v.ScreenToMenuBarItem(5+6));
 
             // Clicks in the "next" region
-            Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(5+7));
-            Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(5+8));
-            Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(5+9));
-            Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(5+10));
-            Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(5+11));
-            Assert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(5+12));
+            ClassicAssert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(5+7));
+            ClassicAssert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(5+8));
+            ClassicAssert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(5+9));
+            ClassicAssert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(5+10));
+            ClassicAssert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(5+11));
+            ClassicAssert.AreEqual(v.Menus[1], v.ScreenToMenuBarItem(5+12));
 
 
             // Clicks in the "more" region
-            Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(5+13));
-            Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(5+14));
-            Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(5+15));
-            Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(5+16));
-            Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(5+17));
-            Assert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(5+18));
+            ClassicAssert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(5+13));
+            ClassicAssert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(5+14));
+            ClassicAssert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(5+15));
+            ClassicAssert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(5+16));
+            ClassicAssert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(5+17));
+            ClassicAssert.AreEqual(v.Menus[2], v.ScreenToMenuBarItem(5+18));
 
             // clicks off the end of the right
-            Assert.IsNull(v.ScreenToMenuBarItem(5+19));
+            ClassicAssert.IsNull(v.ScreenToMenuBarItem(5+19));
         }, out _);
     }
 
@@ -132,9 +132,9 @@ internal class MenuBarExtensionsTests : Tests
     public void TestSetShortcut()
     {
         var si = new StatusItem(Key.F, "ff", () => { });
-        Assert.AreEqual(Key.F, si.Shortcut);
+        ClassicAssert.AreEqual(Key.F, si.Shortcut);
         
         si.SetShortcut(Key.B);
-        Assert.AreEqual(Key.B, si.Shortcut);
+        ClassicAssert.AreEqual(Key.B, si.Shortcut);
     }
 }

--- a/tests/MenuBarTests.cs
+++ b/tests/MenuBarTests.cs
@@ -24,9 +24,9 @@ class MenuBarTests : Tests
         var mbOut = (MenuBar)factory.Create(typeof(MenuBar));
 
         // 1 visible root menu (e.g. File)
-        Assert.AreEqual(1, mbOut.Menus.Length);
+        ClassicAssert.AreEqual(1, mbOut.Menus.Length);
         // 1 child menu item (e.g. Open)
-        Assert.AreEqual(1, mbOut.Menus[0].Children.Length);
+        ClassicAssert.AreEqual(1, mbOut.Menus[0].Children.Length);
 
         OperationManager.Instance.Do(new AddViewOperation(mbOut, designOut, "myMenuBar"));
 
@@ -38,9 +38,9 @@ class MenuBarTests : Tests
         var mbIn = designBackIn.View.GetActualSubviews().OfType<MenuBar>().Single();
 
         // 1 visible root menu (e.g. File)
-        Assert.AreEqual(1, mbIn.Menus.Length);
+        ClassicAssert.AreEqual(1, mbIn.Menus.Length);
         // 1 child menu item (e.g. Open)
-        Assert.AreEqual(1, mbIn.Menus[0].Children.Length);
+        ClassicAssert.AreEqual(1, mbIn.Menus[0].Children.Length);
     }
 
     [Test]
@@ -65,12 +65,12 @@ class MenuBarTests : Tests
         new MoveMenuItemRightOperation(mbOut.Menus[0].Children[1]).Do();
 
         // 1 visible root menu (e.g. File)
-        Assert.AreEqual(1, mbOut.Menus.Length);
+        ClassicAssert.AreEqual(1, mbOut.Menus.Length);
         // 3 child menu item (original one + 3 we added -1 because we moved it to submenu)
-        Assert.AreEqual(3, mbOut.Menus[0].Children.Length);
+        ClassicAssert.AreEqual(3, mbOut.Menus[0].Children.Length);
 
         // should be 1 submenu item (the one we moved)
-        Assert.AreEqual(1, ((MenuBarItem)mbOut.Menus[0].Children[0]).Children.Length);
+        ClassicAssert.AreEqual(1, ((MenuBarItem)mbOut.Menus[0].Children[0]).Children.Length);
 
         viewToCode.GenerateDesignerCs(designOut, typeof(Dialog));
 
@@ -80,12 +80,12 @@ class MenuBarTests : Tests
         var mbIn = designBackIn.View.GetActualSubviews().OfType<MenuBar>().Single();
 
         // 1 visible root menu (e.g. File)
-        Assert.AreEqual(1, mbIn.Menus.Length);
+        ClassicAssert.AreEqual(1, mbIn.Menus.Length);
         // 3 child menu item (original one + 3 we added -1 because we moved it to submenu)
-        Assert.AreEqual(3, mbIn.Menus[0].Children.Length);
+        ClassicAssert.AreEqual(3, mbIn.Menus[0].Children.Length);
 
         // should be 1 submenu item (the one we moved)
-        Assert.AreEqual(1, ((MenuBarItem)mbIn.Menus[0].Children[0]).Children.Length);
+        ClassicAssert.AreEqual(1, ((MenuBarItem)mbIn.Menus[0].Children[0]).Children.Length);
     }
 
     [Test]
@@ -102,9 +102,9 @@ class MenuBarTests : Tests
         MenuTracker.Instance.Register(mbOut);
 
         // 1 visible root menu (e.g. File)
-        Assert.AreEqual(1, mbOut.Menus.Length);
+        ClassicAssert.AreEqual(1, mbOut.Menus.Length);
         // 1 child menu item (e.g. Open)
-        Assert.AreEqual(1, mbOut.Menus[0].Children.Length);
+        ClassicAssert.AreEqual(1, mbOut.Menus[0].Children.Length);
 
         var orig = mbOut.Menus[0].Children[0];
 
@@ -112,59 +112,59 @@ class MenuBarTests : Tests
             new AddMenuItemOperation(mbOut.Menus[0].Children[0]));
 
         // Now 2 child menu item
-        Assert.AreEqual(2, mbOut.Menus[0].Children.Length);
-        Assert.AreSame(orig, mbOut.Menus[0].Children[0]); // original is still at top
+        ClassicAssert.AreEqual(2, mbOut.Menus[0].Children.Length);
+        ClassicAssert.AreSame(orig, mbOut.Menus[0].Children[0]); // original is still at top
 
         OperationManager.Instance.Undo();
 
         // Now only 1 child menu item
-        Assert.AreEqual(1, mbOut.Menus[0].Children.Length);
-        Assert.AreSame(orig, mbOut.Menus[0].Children[0]); // original is still at top
+        ClassicAssert.AreEqual(1, mbOut.Menus[0].Children.Length);
+        ClassicAssert.AreSame(orig, mbOut.Menus[0].Children[0]); // original is still at top
 
         OperationManager.Instance.Redo();
 
         // Now 2 child menu item
-        Assert.AreEqual(2, mbOut.Menus[0].Children.Length);
-        Assert.AreSame(orig, mbOut.Menus[0].Children[0]); // original is still at top
+        ClassicAssert.AreEqual(2, mbOut.Menus[0].Children.Length);
+        ClassicAssert.AreSame(orig, mbOut.Menus[0].Children[0]); // original is still at top
 
         // Now test moving an item around
         var toMove = mbOut.Menus[0].Children[1];
 
         // Move second menu item up
         var up = new MoveMenuItemOperation(toMove, true);
-        Assert.IsFalse(up.IsImpossible);
+        ClassicAssert.IsFalse(up.IsImpossible);
         OperationManager.Instance.Do(up);
 
         // Original one should now be bottom
-        Assert.AreSame(orig, mbOut.Menus[0].Children[1]);
+        ClassicAssert.AreSame(orig, mbOut.Menus[0].Children[1]);
 
         // can't move top one up
-        Assert.IsTrue(new MoveMenuItemOperation(toMove, true).IsImpossible);
+        ClassicAssert.IsTrue(new MoveMenuItemOperation(toMove, true).IsImpossible);
         // cant move bottom one down
-        Assert.IsTrue(new MoveMenuItemOperation(mbOut.Menus[0].Children[1], false).IsImpossible);
+        ClassicAssert.IsTrue(new MoveMenuItemOperation(mbOut.Menus[0].Children[1], false).IsImpossible);
 
         OperationManager.Instance.Undo();
 
         // Original one should be back on top
-        Assert.AreSame(orig, mbOut.Menus[0].Children[0]);
+        ClassicAssert.AreSame(orig, mbOut.Menus[0].Children[0]);
 
         // test moving the top one down
         var toMove2 = mbOut.Menus[0].Children[1];
 
         // Move first menu item down
         var down = new MoveMenuItemOperation(toMove2, true);
-        Assert.IsFalse(down.IsImpossible);
+        ClassicAssert.IsFalse(down.IsImpossible);
         OperationManager.Instance.Do(down);
 
         // Original one should now be bottom
-        Assert.AreSame(orig, mbOut.Menus[0].Children[1]);
-        Assert.AreNotSame(orig, mbOut.Menus[0].Children[0]);
+        ClassicAssert.AreSame(orig, mbOut.Menus[0].Children[1]);
+        ClassicAssert.AreNotSame(orig, mbOut.Menus[0].Children[0]);
 
         OperationManager.Instance.Undo();
 
         // should be back to how we started now
-        Assert.AreSame(orig, mbOut.Menus[0].Children[0]);
-        Assert.AreNotSame(orig, mbOut.Menus[0].Children[1]);
+        ClassicAssert.AreSame(orig, mbOut.Menus[0].Children[0]);
+        ClassicAssert.AreNotSame(orig, mbOut.Menus[0].Children[1]);
     }
 
     private MenuBar GetMenuBar()
@@ -178,12 +178,12 @@ class MenuBarTests : Tests
 
         var bar = (MenuBar)new ViewFactory().Create(typeof(MenuBar));
         var addBarCmd = new AddViewOperation(bar, root, "mb");
-        Assert.IsTrue(addBarCmd.Do());
+        ClassicAssert.IsTrue(addBarCmd.Do());
 
         // Expect ViewFactory to have created a single
         // placeholder menu item
-        Assert.AreEqual(1, bar.Menus.Length);
-        Assert.AreEqual(1, bar.Menus[0].Children.Length);
+        ClassicAssert.AreEqual(1, bar.Menus.Length);
+        ClassicAssert.AreEqual(1, bar.Menus[0].Children.Length);
 
         return bar;
     }
@@ -204,15 +204,15 @@ class MenuBarTests : Tests
         var remove = new RemoveMenuItemOperation(placeholderMenuItem);
 
         // we are able to remove the last one
-        Assert.IsTrue(remove.Do());
-        Assert.IsEmpty(bar.Menus, "menu bar should now be completely empty");
+        ClassicAssert.IsTrue(remove.Do());
+        ClassicAssert.IsEmpty(bar.Menus, "menu bar should now be completely empty");
 
         remove.Undo();
 
         // should be back to where we started
-        Assert.AreEqual(1, bar.Menus.Length);
-        Assert.AreEqual(1, bar.Menus[0].Children.Length);
-        Assert.AreSame(placeholderMenuItem, bar.Menus[0].Children[0]);
+        ClassicAssert.AreEqual(1, bar.Menus.Length);
+        ClassicAssert.AreEqual(1, bar.Menus[0].Children.Length);
+        ClassicAssert.AreSame(placeholderMenuItem, bar.Menus[0].Children[0]);
     }
 
     /// <summary>
@@ -226,7 +226,7 @@ class MenuBarTests : Tests
 
         var mi = bar.Menus[0].Children[0];
         var cmd = new MoveMenuItemRightOperation(mi);
-        Assert.IsFalse(cmd.Do());
+        ClassicAssert.IsFalse(cmd.Do());
     }
 
     [Test]
@@ -238,15 +238,15 @@ class MenuBarTests : Tests
         mi.Data = "yarg";
         mi.Shortcut = Key.Y | Key.CtrlMask;
         var addAnother = new AddMenuItemOperation(mi);
-        Assert.True(addAnother.Do());
+        ClassicAssert.True(addAnother.Do());
 
         // should have added below us
-        Assert.AreSame(mi, bar.Menus[0].Children[0]);
-        Assert.AreNotSame(mi, bar.Menus[0].Children[1]);
-        Assert.AreEqual(2, bar.Menus[0].Children.Length);
+        ClassicAssert.AreSame(mi, bar.Menus[0].Children[0]);
+        ClassicAssert.AreNotSame(mi, bar.Menus[0].Children[1]);
+        ClassicAssert.AreEqual(2, bar.Menus[0].Children.Length);
 
         // cannot move element 0
-        Assert.IsFalse(new MoveMenuItemRightOperation(
+        ClassicAssert.IsFalse(new MoveMenuItemRightOperation(
             bar.Menus[0].Children[0])
         .Do());
 
@@ -254,22 +254,22 @@ class MenuBarTests : Tests
                     bar.Menus[0].Children[1]);
 
         // can move element 1
-        Assert.IsTrue(cmd.Do());
+        ClassicAssert.IsTrue(cmd.Do());
 
         // We will have changed from a MenuItem to a MenuBarItem
         // so element 0 will not be us.  In Terminal.Gui there is
         // a different class for a menu item and one with submenus
-        Assert.AreNotSame(mi, bar.Menus[0].Children[0]);
-        Assert.AreEqual(mi.Title, bar.Menus[0].Children[0].Title);
-        Assert.AreEqual(mi.Data, bar.Menus[0].Children[0].Data);
-        Assert.AreEqual(1, bar.Menus[0].Children.Length);
+        ClassicAssert.AreNotSame(mi, bar.Menus[0].Children[0]);
+        ClassicAssert.AreEqual(mi.Title, bar.Menus[0].Children[0].Title);
+        ClassicAssert.AreEqual(mi.Data, bar.Menus[0].Children[0].Data);
+        ClassicAssert.AreEqual(1, bar.Menus[0].Children.Length);
 
         cmd.Undo();
 
-        Assert.AreEqual(mi.Title, bar.Menus[0].Children[0].Title);
-        Assert.AreEqual(mi.Data, bar.Menus[0].Children[0].Data);
-        Assert.AreEqual(mi.Shortcut, bar.Menus[0].Children[0].Shortcut);
-        Assert.AreNotSame(mi, bar.Menus[0].Children[1]);
+        ClassicAssert.AreEqual(mi.Title, bar.Menus[0].Children[0].Title);
+        ClassicAssert.AreEqual(mi.Data, bar.Menus[0].Children[0].Data);
+        ClassicAssert.AreEqual(mi.Shortcut, bar.Menus[0].Children[0].Shortcut);
+        ClassicAssert.AreNotSame(mi, bar.Menus[0].Children[1]);
     }
 
     [Test]
@@ -280,7 +280,7 @@ class MenuBarTests : Tests
         var mi = bar.Menus[0].Children[0];
 
         // cannot move a root item
-        Assert.IsFalse(new MoveMenuItemLeftOperation(
+        ClassicAssert.IsFalse(new MoveMenuItemLeftOperation(
             bar.Menus[0].Children[0])
         .Do());
     }
@@ -330,36 +330,36 @@ class MenuBarTests : Tests
     {
         var bar = this.GetMenuBarWithSubmenuItems(out var head2, out var topChild);
 
-        Assert.AreEqual(3, bar.Menus[0].Children.Length);
-        Assert.AreEqual(2, head2.Children.Length);
-        Assert.AreSame(topChild, head2.Children[0]);
+        ClassicAssert.AreEqual(3, bar.Menus[0].Children.Length);
+        ClassicAssert.AreEqual(2, head2.Children.Length);
+        ClassicAssert.AreSame(topChild, head2.Children[0]);
 
         var cmd = new MoveMenuItemLeftOperation(topChild);
-        Assert.IsTrue(cmd.Do());
+        ClassicAssert.IsTrue(cmd.Do());
 
         // move the top child left should pull
         // it out of the submenu and onto the root
-        Assert.AreEqual(4, bar.Menus[0].Children.Length);
-        Assert.AreEqual(1, head2.Children.Length);
+        ClassicAssert.AreEqual(4, bar.Menus[0].Children.Length);
+        ClassicAssert.AreEqual(1, head2.Children.Length);
 
         // it should be pulled out underneath its parent
         // and preserve its (Name) and Shortcuts
-        Assert.AreEqual(topChild.Title, bar.Menus[0].Children[2].Title);
-        Assert.AreEqual(topChild.Data, bar.Menus[0].Children[2].Data);
-        Assert.AreEqual(topChild.Shortcut, bar.Menus[0].Children[2].Shortcut);
-        Assert.AreSame(topChild, bar.Menus[0].Children[2]);
+        ClassicAssert.AreEqual(topChild.Title, bar.Menus[0].Children[2].Title);
+        ClassicAssert.AreEqual(topChild.Data, bar.Menus[0].Children[2].Data);
+        ClassicAssert.AreEqual(topChild.Shortcut, bar.Menus[0].Children[2].Shortcut);
+        ClassicAssert.AreSame(topChild, bar.Menus[0].Children[2]);
 
         // undoing command should return us to
         // previous state
         cmd.Undo();
 
-        Assert.AreEqual(3, bar.Menus[0].Children.Length);
-        Assert.AreEqual(2, head2.Children.Length);
+        ClassicAssert.AreEqual(3, bar.Menus[0].Children.Length);
+        ClassicAssert.AreEqual(2, head2.Children.Length);
 
-        Assert.AreEqual(topChild.Title.ToString(), head2.Children[0].Title.ToString());
-        Assert.AreEqual(topChild.Data, head2.Children[0].Data);
-        Assert.AreEqual(topChild.Shortcut, head2.Children[0].Shortcut);
-        Assert.AreSame(topChild, head2.Children[0]);
+        ClassicAssert.AreEqual(topChild.Title.ToString(), head2.Children[0].Title.ToString());
+        ClassicAssert.AreEqual(topChild.Data, head2.Children[0].Data);
+        ClassicAssert.AreEqual(topChild.Shortcut, head2.Children[0].Shortcut);
+        ClassicAssert.AreSame(topChild, head2.Children[0]);
     }
 
     [Test]
@@ -367,24 +367,24 @@ class MenuBarTests : Tests
     {
         var bar = this.GetMenuBarWithSubmenuItems(out var head2, out var topChild);
 
-        Assert.AreEqual(3, bar.Menus[0].Children.Length);
-        Assert.AreEqual(2, head2.Children.Length);
-        Assert.AreSame(topChild, head2.Children[0]);
+        ClassicAssert.AreEqual(3, bar.Menus[0].Children.Length);
+        ClassicAssert.AreEqual(2, head2.Children.Length);
+        ClassicAssert.AreSame(topChild, head2.Children[0]);
 
         var cmd = new RemoveMenuItemOperation(topChild);
-        Assert.IsTrue(cmd.Do());
+        ClassicAssert.IsTrue(cmd.Do());
 
         // Delete the top child should leave only 1 in submenu
-        Assert.AreEqual(3, bar.Menus[0].Children.Length);
-        Assert.AreEqual(1, head2.Children.Length);
-        Assert.AreNotSame(topChild, head2.Children[0]);
+        ClassicAssert.AreEqual(3, bar.Menus[0].Children.Length);
+        ClassicAssert.AreEqual(1, head2.Children.Length);
+        ClassicAssert.AreNotSame(topChild, head2.Children[0]);
 
         cmd.Undo();
 
         // should come back now
-        Assert.AreEqual(3, bar.Menus[0].Children.Length);
-        Assert.AreEqual(2, head2.Children.Length);
-        Assert.AreSame(topChild, head2.Children[0]);
+        ClassicAssert.AreEqual(3, bar.Menus[0].Children.Length);
+        ClassicAssert.AreEqual(2, head2.Children.Length);
+        ClassicAssert.AreSame(topChild, head2.Children[0]);
     }
 
     [Test]
@@ -393,36 +393,36 @@ class MenuBarTests : Tests
         var bar = this.GetMenuBarWithSubmenuItems(out var head2, out var topChild);
         var bottomChild = head2.Children[1];
 
-        Assert.AreEqual(3, bar.Menus[0].Children.Length);
-        Assert.AreEqual(typeof(MenuBarItem), bar.Menus[0].Children[1].GetType());
-        Assert.AreEqual(2, head2.Children.Length);
-        Assert.AreSame(topChild, head2.Children[0]);
+        ClassicAssert.AreEqual(3, bar.Menus[0].Children.Length);
+        ClassicAssert.AreEqual(typeof(MenuBarItem), bar.Menus[0].Children[1].GetType());
+        ClassicAssert.AreEqual(2, head2.Children.Length);
+        ClassicAssert.AreSame(topChild, head2.Children[0]);
 
         var cmd1 = new RemoveMenuItemOperation(topChild);
-        Assert.IsTrue(cmd1.Do());
+        ClassicAssert.IsTrue(cmd1.Do());
 
         var cmd2 = new RemoveMenuItemOperation(bottomChild);
-        Assert.IsTrue(cmd2.Do());
+        ClassicAssert.IsTrue(cmd2.Do());
 
         // Deleting both children should convert us from
         // a dropdown submenu to just a regular MenuItem
-        Assert.AreEqual(3, bar.Menus[0].Children.Length);
-        Assert.AreEqual(typeof(MenuItem), bar.Menus[0].Children[1].GetType());
+        ClassicAssert.AreEqual(3, bar.Menus[0].Children.Length);
+        ClassicAssert.AreEqual(typeof(MenuItem), bar.Menus[0].Children[1].GetType());
 
         cmd2.Undo();
 
         // should bring the bottom one back
-        Assert.AreEqual(3, bar.Menus[0].Children.Length);
-        Assert.AreEqual(typeof(MenuBarItem), bar.Menus[0].Children[1].GetType());
-        Assert.AreSame(bottomChild, ((MenuBarItem)bar.Menus[0].Children[1]).Children[0]);
+        ClassicAssert.AreEqual(3, bar.Menus[0].Children.Length);
+        ClassicAssert.AreEqual(typeof(MenuBarItem), bar.Menus[0].Children[1].GetType());
+        ClassicAssert.AreSame(bottomChild, ((MenuBarItem)bar.Menus[0].Children[1]).Children[0]);
 
         cmd1.Undo();
 
         // Both submenu items should now be back
-        Assert.AreEqual(3, bar.Menus[0].Children.Length);
-        Assert.AreEqual(typeof(MenuBarItem), bar.Menus[0].Children[1].GetType());
-        Assert.AreSame(topChild, ((MenuBarItem)bar.Menus[0].Children[1]).Children[0]);
-        Assert.AreSame(bottomChild, ((MenuBarItem)bar.Menus[0].Children[1]).Children[1]);
+        ClassicAssert.AreEqual(3, bar.Menus[0].Children.Length);
+        ClassicAssert.AreEqual(typeof(MenuBarItem), bar.Menus[0].Children[1].GetType());
+        ClassicAssert.AreSame(topChild, ((MenuBarItem)bar.Menus[0].Children[1]).Children[0]);
+        ClassicAssert.AreSame(bottomChild, ((MenuBarItem)bar.Menus[0].Children[1]).Children[1]);
     }
 
     [Test]
@@ -432,21 +432,21 @@ class MenuBarTests : Tests
 
         var mi = bar.Menus[0].Children[0];
 
-        Assert.Contains(bar, root.View.Subviews.ToArray(),
+        ClassicAssert.Contains(bar, root.View.Subviews.ToArray(),
                 "The MenuBar should be on the main view being edited");
 
         var cmd = new RemoveMenuItemOperation(mi);
-        Assert.IsTrue(cmd.Do());
+        ClassicAssert.IsTrue(cmd.Do());
 
-        Assert.IsEmpty(bar.Menus, "Expected menu bar header (File) to be removed along with it's last (only) child");
+        ClassicAssert.IsEmpty(bar.Menus, "Expected menu bar header (File) to be removed along with it's last (only) child");
 
-        Assert.IsFalse(
+        ClassicAssert.IsFalse(
             root.View.Subviews.Contains(bar),
             "Now that the MenuBar is completely empty it should be automatically removed");
 
         cmd.Undo();
 
-        Assert.Contains(bar, root.View.Subviews.ToArray(),
+        ClassicAssert.Contains(bar, root.View.Subviews.ToArray(),
                 "Undo should put the MenuBar back on the view again");
     }
 }

--- a/tests/MouseManagerTests.cs
+++ b/tests/MouseManagerTests.cs
@@ -23,8 +23,8 @@ internal class MouseManagerTests : Tests
         var mgr = new MouseManager();
 
         // we haven't done anything yet
-        Assert.AreEqual(0, OperationManager.Instance.UndoStackSize);
-        Assert.AreEqual(0, lbl.Bounds.Y);
+        ClassicAssert.AreEqual(0, OperationManager.Instance.UndoStackSize);
+        ClassicAssert.AreEqual(0, lbl.Bounds.Y);
 
         // user presses down over the control
         var e = new MouseEvent
@@ -36,10 +36,10 @@ internal class MouseManagerTests : Tests
 
         mgr.HandleMouse(e, d);
 
-        Assert.AreEqual(0, lbl.Bounds.Y);
+        ClassicAssert.AreEqual(0, lbl.Bounds.Y);
 
         // we still haven't committed to anything
-        Assert.AreEqual(0, OperationManager.Instance.UndoStackSize);
+        ClassicAssert.AreEqual(0, OperationManager.Instance.UndoStackSize);
 
         // user pulled view down but still has mouse down
         e = new MouseEvent
@@ -50,10 +50,10 @@ internal class MouseManagerTests : Tests
         };
         mgr.HandleMouse(e, d);
 
-        Assert.AreEqual((Pos)1, lbl.Y);
+        ClassicAssert.AreEqual((Pos)1, lbl.Y);
 
         // we still haven't committed to anything
-        Assert.AreEqual(0, OperationManager.Instance.UndoStackSize);
+        ClassicAssert.AreEqual(0, OperationManager.Instance.UndoStackSize);
 
         // user releases mouse (in place)
         e = new MouseEvent
@@ -63,10 +63,10 @@ internal class MouseManagerTests : Tests
         };
         mgr.HandleMouse(e, d);
 
-        Assert.AreEqual((Pos)1, lbl.Y);
+        ClassicAssert.AreEqual((Pos)1, lbl.Y);
 
         // we have now committed the drag so could undo
-        Assert.AreEqual(1, OperationManager.Instance.UndoStackSize);
+        ClassicAssert.AreEqual(1, OperationManager.Instance.UndoStackSize);
     }
 
     [TestCase(typeof(Button))]
@@ -85,15 +85,15 @@ internal class MouseManagerTests : Tests
         view.Data = design;
         d.View.Add(view);
 
-        Assert.AreEqual(8, view.Bounds.Width);
+        ClassicAssert.AreEqual(8, view.Bounds.Width);
         var mgr = new MouseManager();
 
         // we haven't done anything yet
-        Assert.AreEqual(0, OperationManager.Instance.UndoStackSize);
-        Assert.AreEqual(0, view.Bounds.X);
-        Assert.AreEqual(0, view.Bounds.Y);
-        Assert.AreEqual(8, view.Bounds.Width);
-        Assert.AreEqual(1, view.Bounds.Height);
+        ClassicAssert.AreEqual(0, OperationManager.Instance.UndoStackSize);
+        ClassicAssert.AreEqual(0, view.Bounds.X);
+        ClassicAssert.AreEqual(0, view.Bounds.Y);
+        ClassicAssert.AreEqual(8, view.Bounds.Width);
+        ClassicAssert.AreEqual(1, view.Bounds.Height);
 
         // user presses down in the lower right of control
         var e = new MouseEvent
@@ -105,10 +105,10 @@ internal class MouseManagerTests : Tests
 
         mgr.HandleMouse(e, d);
 
-        Assert.AreEqual(0, view.Bounds.Y);
+        ClassicAssert.AreEqual(0, view.Bounds.Y);
 
         // we still haven't committed to anything
-        Assert.AreEqual(0, OperationManager.Instance.UndoStackSize);
+        ClassicAssert.AreEqual(0, OperationManager.Instance.UndoStackSize);
 
         // user pulled view size +1 width and +1 height
         e = new MouseEvent
@@ -119,13 +119,13 @@ internal class MouseManagerTests : Tests
         };
         mgr.HandleMouse(e, d);
 
-        Assert.AreEqual(0, view.Bounds.X);
-        Assert.AreEqual(0, view.Bounds.Y);
-        Assert.AreEqual(10, view.Bounds.Width, "Expected resize to increase Width when dragging");
-        Assert.AreEqual(1, view.Bounds.Height, "Expected resize of button to ignore Y component");
+        ClassicAssert.AreEqual(0, view.Bounds.X);
+        ClassicAssert.AreEqual(0, view.Bounds.Y);
+        ClassicAssert.AreEqual(10, view.Bounds.Width, "Expected resize to increase Width when dragging");
+        ClassicAssert.AreEqual(1, view.Bounds.Height, "Expected resize of button to ignore Y component");
 
         // we still haven't committed to anything
-        Assert.AreEqual(0, OperationManager.Instance.UndoStackSize);
+        ClassicAssert.AreEqual(0, OperationManager.Instance.UndoStackSize);
 
         // user releases mouse (in place)
         e = new MouseEvent
@@ -135,13 +135,13 @@ internal class MouseManagerTests : Tests
         };
         mgr.HandleMouse(e, d);
 
-        Assert.AreEqual(0, view.Bounds.X);
-        Assert.AreEqual(0, view.Bounds.Y);
-        Assert.AreEqual(10, view.Bounds.Width, "Expected resize to increase Width when dragging");
-        Assert.AreEqual(1, view.Bounds.Height, "Expected resize of button to ignore Y component");
+        ClassicAssert.AreEqual(0, view.Bounds.X);
+        ClassicAssert.AreEqual(0, view.Bounds.Y);
+        ClassicAssert.AreEqual(10, view.Bounds.Width, "Expected resize to increase Width when dragging");
+        ClassicAssert.AreEqual(1, view.Bounds.Height, "Expected resize of button to ignore Y component");
 
         // we have now committed the drag so could undo
-        Assert.AreEqual(1, OperationManager.Instance.UndoStackSize);
+        ClassicAssert.AreEqual(1, OperationManager.Instance.UndoStackSize);
     }
 
     [TestCase(1, 1, 4, 6, new[] { 0, 2 })] // drag from 1,1 to 4,6 and expect labels 0 and 2 to be selected
@@ -207,14 +207,14 @@ internal class MouseManagerTests : Tests
 
         // do not expect dragging selection box to change anything
         // or be undoable
-        Assert.AreEqual(0, OperationManager.Instance.UndoStackSize);
+        ClassicAssert.AreEqual(0, OperationManager.Instance.UndoStackSize);
 
         // for each selectable thing
         for (int i = 0; i < labels.Length; i++)
         {
             // its selection status should match the expectation
             // passed in the test case
-            Assert.AreEqual(
+            ClassicAssert.AreEqual(
                 expectSelected.Contains(i),
                 selection.Selected.ToList().Contains(labels[i]),
                 $"Expectation wrong for label index {i} (indexes are 0 based)");
@@ -239,8 +239,8 @@ internal class MouseManagerTests : Tests
 
         d.View.Add(lbl1);
 
-        Assert.AreEqual(Dim.Sized(1), lbl1.Width);
-        Assert.AreEqual(Dim.Sized(1), lbl1.Height);
+        ClassicAssert.AreEqual(Dim.Sized(1), lbl1.Width);
+        ClassicAssert.AreEqual(Dim.Sized(1), lbl1.Height);
 
         var selection = SelectionManager.Instance;
         selection.Clear();
@@ -274,12 +274,12 @@ internal class MouseManagerTests : Tests
         mgr.HandleMouse(e, d);
 
         // do not expect dragging to resize
-        Assert.AreEqual(Dim.Sized(1), lbl1.Width);
-        Assert.AreEqual(Dim.Sized(1), lbl1.Height);
+        ClassicAssert.AreEqual(Dim.Sized(1), lbl1.Width);
+        ClassicAssert.AreEqual(Dim.Sized(1), lbl1.Height);
 
         // expect drag move instead
 
-        Assert.AreEqual(Pos.At(4), lbl1.X);
-        Assert.AreEqual(Pos.At(6), lbl1.Y);
+        ClassicAssert.AreEqual(Pos.At(4), lbl1.X);
+        ClassicAssert.AreEqual(Pos.At(6), lbl1.Y);
     }
 }

--- a/tests/Operations/AddColumnOperationTests.cs
+++ b/tests/Operations/AddColumnOperationTests.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using System;
 using Terminal.Gui;
 using TerminalGuiDesigner.Operations.TableViewOperations;
@@ -13,7 +13,7 @@ internal class AddColumnOperationTests : Tests
         var d = Get10By10View();
         var ex = Assert.Throws<ArgumentException>(() => new AddColumnOperation(d, null));
 
-        Assert.AreEqual("Design must wrap a TableView to be used with this operation.", ex?.Message);
+        ClassicAssert.AreEqual("Design must wrap a TableView to be used with this operation.", ex?.Message);
     }
     
     [Test]
@@ -30,12 +30,12 @@ internal class AddColumnOperationTests : Tests
             var op = new AddColumnOperation(d, "MyCol");
             op.Do();
 
-            Assert.AreEqual(colsBefore + 1, v.Table.Columns.Count, "Expected AddColumnOperation to increase column count by 1");
+            ClassicAssert.AreEqual(colsBefore + 1, v.Table.Columns.Count, "Expected AddColumnOperation to increase column count by 1");
 
         }, out var vAfter);
 
-        Assert.AreEqual(colsBefore + 1, vAfter.Table.Columns.Count);
-        Assert.AreEqual(colsBefore + 1, vBefore?.Table.Columns.Count);
+        ClassicAssert.AreEqual(colsBefore + 1, vAfter.Table.Columns.Count);
+        ClassicAssert.AreEqual(colsBefore + 1, vBefore?.Table.Columns.Count);
     }
 
     [Test]
@@ -51,15 +51,15 @@ internal class AddColumnOperationTests : Tests
 
             var op = new AddColumnOperation(d, "MyCol");
             op.Do();
-            Assert.AreEqual(colsBefore + 1, v.Table.Columns.Count, "Expected AddColumnOperation to increase column count by 1");
+            ClassicAssert.AreEqual(colsBefore + 1, v.Table.Columns.Count, "Expected AddColumnOperation to increase column count by 1");
 
             op.Undo();
-            Assert.AreEqual(colsBefore, v.Table.Columns.Count, "Expected AddColumnOperation Undo to go back to original count");
+            ClassicAssert.AreEqual(colsBefore, v.Table.Columns.Count, "Expected AddColumnOperation Undo to go back to original count");
 
         }, out var vAfter);
 
-        Assert.AreEqual(colsBefore, vAfter.Table.Columns.Count);
-        Assert.AreEqual(colsBefore, vBefore?.Table.Columns.Count);
+        ClassicAssert.AreEqual(colsBefore, vAfter.Table.Columns.Count);
+        ClassicAssert.AreEqual(colsBefore, vBefore?.Table.Columns.Count);
     }
 
     [Test]
@@ -78,12 +78,12 @@ internal class AddColumnOperationTests : Tests
             var op = new AddColumnOperation(d, "Test");
             op.Do();
 
-            Assert.AreEqual("Test2", v.Table.Columns[colsBefore].ColumnName);
-            Assert.AreEqual(colsBefore + 1, v.Table.Columns.Count, "Expected AddColumnOperation to increase column count by 1");
+            ClassicAssert.AreEqual("Test2", v.Table.Columns[colsBefore].ColumnName);
+            ClassicAssert.AreEqual(colsBefore + 1, v.Table.Columns.Count, "Expected AddColumnOperation to increase column count by 1");
 
         }, out var vAfter);
 
-        Assert.AreEqual(colsBefore+1, vAfter.Table.Columns.Count);
-        Assert.AreEqual(colsBefore+1, vBefore?.Table.Columns.Count);
+        ClassicAssert.AreEqual(colsBefore+1, vAfter.Table.Columns.Count);
+        ClassicAssert.AreEqual(colsBefore+1, vBefore?.Table.Columns.Count);
     }
 }

--- a/tests/Operations/AddMenuItemOperationTests.cs
+++ b/tests/Operations/AddMenuItemOperationTests.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using Terminal.Gui;
 using TerminalGuiDesigner.Operations.MenuOperations;
 
@@ -15,26 +15,26 @@ internal class AddMenuItemOperationTests : Tests
 
         var viewIn = RoundTrip<View, MenuBar>((d, v) =>
         {
-            Assert.IsNotNull(v.Menus[0].Children[0], "Expected a new MenuBar added in Designer to have a placeholder MenuItem entry");
-            Assert.AreEqual(1, v.Menus[0].Children.Length);
+            ClassicAssert.IsNotNull(v.Menus[0].Children[0], "Expected a new MenuBar added in Designer to have a placeholder MenuItem entry");
+            ClassicAssert.AreEqual(1, v.Menus[0].Children.Length);
             var first = v.Menus[0].Children[0];
             firstMenuItemName = first.Title.ToString();
 
             var add = new AddMenuItemOperation(first);
 
-            Assert.IsNotNull(v.Menus[0].Children[0], "Expected no changes until we actually run the operation");
-            Assert.AreEqual(1, v.Menus[0].Children.Length);
+            ClassicAssert.IsNotNull(v.Menus[0].Children[0], "Expected no changes until we actually run the operation");
+            ClassicAssert.AreEqual(1, v.Menus[0].Children.Length);
 
             add.Do();
             
-            Assert.AreEqual(2, v.Menus[0].Children.Length);
-            Assert.AreSame(first, v.Menus[0].Children[0], "Expected new item to be below the original (unchanged) item");
-            Assert.AreEqual("", v.Menus[0].Children[1].Title.ToString(),"Expected new menu items to have no text initially (user Types to enter them)");
+            ClassicAssert.AreEqual(2, v.Menus[0].Children.Length);
+            ClassicAssert.AreSame(first, v.Menus[0].Children[0], "Expected new item to be below the original (unchanged) item");
+            ClassicAssert.AreEqual("", v.Menus[0].Children[1].Title.ToString(),"Expected new menu items to have no text initially (user Types to enter them)");
         }, out _);
 
-        Assert.AreEqual(2, viewIn.Menus[0].Children.Length);
-        Assert.AreEqual(firstMenuItemName, viewIn.Menus[0].Children[0].Title.ToString(), "Expected save/reload to have no effect on menu names");
-        Assert.AreEqual("", viewIn.Menus[0].Children[1].Title.ToString());
+        ClassicAssert.AreEqual(2, viewIn.Menus[0].Children.Length);
+        ClassicAssert.AreEqual(firstMenuItemName, viewIn.Menus[0].Children[0].Title.ToString(), "Expected save/reload to have no effect on menu names");
+        ClassicAssert.AreEqual("", viewIn.Menus[0].Children[1].Title.ToString());
     }
 
     [Test]
@@ -46,42 +46,42 @@ internal class AddMenuItemOperationTests : Tests
 
         var viewIn = RoundTrip<View, MenuBar>((d, v) =>
         {
-            Assert.IsNotNull(v.Menus[0].Children[0], "Expected a new MenuBar added in Designer to have a placeholder MenuItem entry");
-            Assert.AreEqual(1, v.Menus[0].Children.Length);
+            ClassicAssert.IsNotNull(v.Menus[0].Children[0], "Expected a new MenuBar added in Designer to have a placeholder MenuItem entry");
+            ClassicAssert.AreEqual(1, v.Menus[0].Children.Length);
             var first = v.Menus[0].Children[0];
             firstMenuItemName = first.Title.ToString();
 
             var add = new AddMenuItemOperation(first);
 
-            Assert.IsNotNull(v.Menus[0].Children[0], "Expected no changes until we actually run the operation");
-            Assert.AreEqual(1, v.Menus[0].Children.Length);
+            ClassicAssert.IsNotNull(v.Menus[0].Children[0], "Expected no changes until we actually run the operation");
+            ClassicAssert.AreEqual(1, v.Menus[0].Children.Length);
 
             add.Do();
-            Assert.AreEqual(2, v.Menus[0].Children.Length);
-            Assert.AreSame(first, v.Menus[0].Children[0], "Expected new item to be below the original (unchanged) item");
-            Assert.AreEqual("", v.Menus[0].Children[1].Title.ToString(), "Expected new menu items to have no text initially (user Types to enter them)");
+            ClassicAssert.AreEqual(2, v.Menus[0].Children.Length);
+            ClassicAssert.AreSame(first, v.Menus[0].Children[0], "Expected new item to be below the original (unchanged) item");
+            ClassicAssert.AreEqual("", v.Menus[0].Children[1].Title.ToString(), "Expected new menu items to have no text initially (user Types to enter them)");
 
             // curve ball undo it a bunch of times and redo
             add.Undo();
-            Assert.AreEqual(1, v.Menus[0].Children.Length);
-            Assert.AreSame(first, v.Menus[0].Children[0], "Expected new item to be below the original (unchanged) item");
+            ClassicAssert.AreEqual(1, v.Menus[0].Children.Length);
+            ClassicAssert.AreSame(first, v.Menus[0].Children[0], "Expected new item to be below the original (unchanged) item");
             add.Undo();
             add.Undo();
 
             add.Redo();
-            Assert.AreEqual(2, v.Menus[0].Children.Length);
-            Assert.AreSame(first, v.Menus[0].Children[0], "Expected new item to be below the original (unchanged) item");
-            Assert.AreEqual("", v.Menus[0].Children[1].Title.ToString(), "Expected new menu items to have no text initially (user Types to enter them)");
+            ClassicAssert.AreEqual(2, v.Menus[0].Children.Length);
+            ClassicAssert.AreSame(first, v.Menus[0].Children[0], "Expected new item to be below the original (unchanged) item");
+            ClassicAssert.AreEqual("", v.Menus[0].Children[1].Title.ToString(), "Expected new menu items to have no text initially (user Types to enter them)");
 
             add.Undo();
             add.Undo();
             add.Undo();
-            Assert.AreEqual(1, v.Menus[0].Children.Length);
-            Assert.AreSame(first, v.Menus[0].Children[0], "Expected new item to be below the original (unchanged) item");
+            ClassicAssert.AreEqual(1, v.Menus[0].Children.Length);
+            ClassicAssert.AreSame(first, v.Menus[0].Children[0], "Expected new item to be below the original (unchanged) item");
 
         }, out _);
 
-        Assert.AreEqual(1, viewIn.Menus[0].Children.Length);
-        Assert.AreEqual(firstMenuItemName, viewIn.Menus[0].Children[0].Title.ToString(), "Expected save/reload to have no effect on menu names");
+        ClassicAssert.AreEqual(1, viewIn.Menus[0].Children.Length);
+        ClassicAssert.AreEqual(firstMenuItemName, viewIn.Menus[0].Children[0].Title.ToString(), "Expected save/reload to have no effect on menu names");
     }
 }

--- a/tests/Operations/AddMenuOperationTests.cs
+++ b/tests/Operations/AddMenuOperationTests.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using System;
 using System.IO;
 using Terminal.Gui;
@@ -14,7 +14,7 @@ internal class AddMenuOperationTests : Tests
     {
         var d = Get10By10View();
         var ex = Assert.Throws<ArgumentException>(() => new AddMenuOperation(d, "haha!"));
-        Assert.AreEqual("Design must wrap a MenuBar to be used with this operation.", ex?.Message);
+        ClassicAssert.AreEqual("Design must wrap a MenuBar to be used with this operation.", ex?.Message);
     }
 
     [Test]
@@ -24,24 +24,24 @@ internal class AddMenuOperationTests : Tests
 
         var viewIn = RoundTrip<View, MenuBar>((d, v) =>
         {
-            Assert.AreEqual(expectedTopLevelMenuName, v.Menus[0].Title.ToString(), "Expected a new MenuBar added in Designer to have a placeholder title");
-            Assert.AreEqual(1, v.Menus.Length, "Expected 1 placeholder example Menu");
+            ClassicAssert.AreEqual(expectedTopLevelMenuName, v.Menus[0].Title.ToString(), "Expected a new MenuBar added in Designer to have a placeholder title");
+            ClassicAssert.AreEqual(1, v.Menus.Length, "Expected 1 placeholder example Menu");
             var first = v.Menus[0];
 
             var add = new AddMenuOperation(d, "Blarg");
-            Assert.AreEqual(1, v.Menus.Length, "Expected no changes until we actually run the operation");
+            ClassicAssert.AreEqual(1, v.Menus.Length, "Expected no changes until we actually run the operation");
 
             add.Do();
 
-            Assert.AreEqual(2, v.Menus.Length, "Expected a new top level menu to be added");
-            Assert.AreSame(first, v.Menus[0], "Expected new item to be right of the original");
-            Assert.AreEqual("Blarg", v.Menus[1].Title.ToString());
+            ClassicAssert.AreEqual(2, v.Menus.Length, "Expected a new top level menu to be added");
+            ClassicAssert.AreSame(first, v.Menus[0], "Expected new item to be right of the original");
+            ClassicAssert.AreEqual("Blarg", v.Menus[1].Title.ToString());
 
         }, out _);
 
-        Assert.AreEqual(2, viewIn.Menus.Length);
-        Assert.AreEqual(expectedTopLevelMenuName, viewIn.Menus[0].Title.ToString());
-        Assert.AreEqual("Blarg", viewIn.Menus[1].Title.ToString());
+        ClassicAssert.AreEqual(2, viewIn.Menus.Length);
+        ClassicAssert.AreEqual(expectedTopLevelMenuName, viewIn.Menus[0].Title.ToString());
+        ClassicAssert.AreEqual("Blarg", viewIn.Menus[1].Title.ToString());
     }
 
     [Test]
@@ -49,16 +49,16 @@ internal class AddMenuOperationTests : Tests
     {
         var viewIn = RoundTrip<View, MenuBar>((d, v) =>
         {
-            Assert.AreEqual(1, v.Menus.Length);
+            ClassicAssert.AreEqual(1, v.Menus.Length);
             var add = new AddMenuOperation(d, "   ");
             add.Do();
-            Assert.AreEqual(2, v.Menus.Length);
-            Assert.AreEqual("blank", v.Menus[1].Title);
+            ClassicAssert.AreEqual(2, v.Menus.Length);
+            ClassicAssert.AreEqual("blank", v.Menus[1].Title);
 
         }, out _);
 
-        Assert.AreEqual(2, viewIn.Menus.Length);
-        Assert.AreEqual("blank", viewIn.Menus[1].Title);
+        ClassicAssert.AreEqual(2, viewIn.Menus.Length);
+        ClassicAssert.AreEqual("blank", viewIn.Menus[1].Title);
     }
 
     [Test]
@@ -66,20 +66,20 @@ internal class AddMenuOperationTests : Tests
     {
         var viewIn = RoundTrip<View, MenuBar>((d, v) =>
         {
-            Assert.AreEqual(1, v.Menus.Length);
+            ClassicAssert.AreEqual(1, v.Menus.Length);
             var add = new AddMenuOperation(d, "Fish");
             add.Do();
             add = new AddMenuOperation(d, "Fish");
             add.Do();
-            Assert.AreEqual(3, v.Menus.Length);
-            Assert.AreEqual("Fish", v.Menus[1].Title.ToString());
-            Assert.AreEqual("Fish2", v.Menus[2].Title.ToString());
+            ClassicAssert.AreEqual(3, v.Menus.Length);
+            ClassicAssert.AreEqual("Fish", v.Menus[1].Title.ToString());
+            ClassicAssert.AreEqual("Fish2", v.Menus[2].Title.ToString());
 
         }, out _);
 
-        Assert.AreEqual(3, viewIn.Menus.Length);
-        Assert.AreEqual("Fish", viewIn.Menus[1].Title.ToString());
-        Assert.AreEqual("Fish2", viewIn.Menus[2].Title.ToString());
+        ClassicAssert.AreEqual(3, viewIn.Menus.Length);
+        ClassicAssert.AreEqual("Fish", viewIn.Menus[1].Title.ToString());
+        ClassicAssert.AreEqual("Fish2", viewIn.Menus[2].Title.ToString());
 
         // Check that the .Designer.cs is producing sensible private field names
         FileAssert.Exists(((Design)viewIn.Data).SourceCode.DesignerFile);
@@ -103,37 +103,37 @@ internal class AddMenuOperationTests : Tests
 
         var viewIn = RoundTrip<View, MenuBar>((d, v) =>
         {
-            Assert.AreEqual(expectedTopLevelMenuName, v.Menus[0].Title.ToString(), "Expected a new MenuBar added in Designer to have a placeholder title");
-            Assert.AreEqual(1, v.Menus.Length, "Expected 1 placeholder example Menu");
+            ClassicAssert.AreEqual(expectedTopLevelMenuName, v.Menus[0].Title.ToString(), "Expected a new MenuBar added in Designer to have a placeholder title");
+            ClassicAssert.AreEqual(1, v.Menus.Length, "Expected 1 placeholder example Menu");
             var first = v.Menus[0];
 
             var add = new AddMenuOperation(d, "Blarg");
-            Assert.AreEqual(1, v.Menus.Length, "Expected no changes until we actually run the operation");
+            ClassicAssert.AreEqual(1, v.Menus.Length, "Expected no changes until we actually run the operation");
 
             add.Do();
-            Assert.AreEqual(2, v.Menus.Length, "Expected a new top level menu to be added");
-            Assert.AreSame(first, v.Menus[0], "Expected new item to be right of the original");
-            Assert.AreEqual("Blarg", v.Menus[1].Title.ToString());
+            ClassicAssert.AreEqual(2, v.Menus.Length, "Expected a new top level menu to be added");
+            ClassicAssert.AreSame(first, v.Menus[0], "Expected new item to be right of the original");
+            ClassicAssert.AreEqual("Blarg", v.Menus[1].Title.ToString());
 
             add.Undo();
-            Assert.AreEqual(expectedTopLevelMenuName, v.Menus[0].Title.ToString());
-            Assert.AreEqual(1, v.Menus.Length);
+            ClassicAssert.AreEqual(expectedTopLevelMenuName, v.Menus[0].Title.ToString());
+            ClassicAssert.AreEqual(1, v.Menus.Length);
 
             add.Redo();
-            Assert.AreEqual(2, v.Menus.Length);
-            Assert.AreSame(first, v.Menus[0]);
-            Assert.AreEqual("Blarg", v.Menus[1].Title.ToString());
+            ClassicAssert.AreEqual(2, v.Menus.Length);
+            ClassicAssert.AreSame(first, v.Menus[0]);
+            ClassicAssert.AreEqual("Blarg", v.Menus[1].Title.ToString());
 
             add.Undo();
             add.Undo();
             add.Undo();
             add.Undo();
-            Assert.AreEqual(expectedTopLevelMenuName, v.Menus[0].Title.ToString());
-            Assert.AreEqual(1, v.Menus.Length);
+            ClassicAssert.AreEqual(expectedTopLevelMenuName, v.Menus[0].Title.ToString());
+            ClassicAssert.AreEqual(1, v.Menus.Length);
 
         }, out _);
 
-        Assert.AreEqual(1, viewIn.Menus.Length);
-        Assert.AreEqual(expectedTopLevelMenuName, viewIn.Menus[0].Title.ToString());
+        ClassicAssert.AreEqual(1, viewIn.Menus.Length);
+        ClassicAssert.AreEqual(expectedTopLevelMenuName, viewIn.Menus[0].Title.ToString());
     }
 }

--- a/tests/Operations/AddTabOperationTests.cs
+++ b/tests/Operations/AddTabOperationTests.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using System;
 using System.Linq;
 using Terminal.Gui;
@@ -13,7 +13,7 @@ internal class AddTabOperationTests : Tests
     {
         var d = Get10By10View();
         var ex = Assert.Throws<ArgumentException>(() => new AddTabOperation(d, null));
-        Assert.AreEqual("Design must wrap a TabView to be used with this operation.", ex?.Message);
+        ClassicAssert.AreEqual("Design must wrap a TabView to be used with this operation.", ex?.Message);
     }
 
     [Test]
@@ -25,26 +25,26 @@ internal class AddTabOperationTests : Tests
         var tabIn = RoundTrip<Toplevel, TabView>(
             (d, v) =>
             {
-                Assert.AreEqual(2, v.Tabs.Count, "Expected ViewFactory TabView to have a couple of example tabs when created");
+                ClassicAssert.AreEqual(2, v.Tabs.Count, "Expected ViewFactory TabView to have a couple of example tabs when created");
                 tab1Name = v.Tabs.ElementAt(0).Text.ToString();
                 tab2Name = v.Tabs.ElementAt(1).Text.ToString();
 
                 var op = new AddTabOperation(d, "Blarg");
-                Assert.AreEqual(2, v.Tabs.Count, "Operation has not been run so why are there new tabs!");
-                Assert.AreEqual(tab1Name, v.Tabs.ElementAt(0).Text);
-                Assert.AreEqual(tab2Name, v.Tabs.ElementAt(1).Text);
+                ClassicAssert.AreEqual(2, v.Tabs.Count, "Operation has not been run so why are there new tabs!");
+                ClassicAssert.AreEqual(tab1Name, v.Tabs.ElementAt(0).Text);
+                ClassicAssert.AreEqual(tab2Name, v.Tabs.ElementAt(1).Text);
 
                 op.Do();
-                Assert.AreEqual(3, v.Tabs.Count);
-                Assert.AreEqual(tab1Name, v.Tabs.ElementAt(0).Text);
-                Assert.AreEqual(tab2Name, v.Tabs.ElementAt(1).Text);
-                Assert.AreEqual("Blarg", v.Tabs.ElementAt(2).Text);
+                ClassicAssert.AreEqual(3, v.Tabs.Count);
+                ClassicAssert.AreEqual(tab1Name, v.Tabs.ElementAt(0).Text);
+                ClassicAssert.AreEqual(tab2Name, v.Tabs.ElementAt(1).Text);
+                ClassicAssert.AreEqual("Blarg", v.Tabs.ElementAt(2).Text);
             }, out _);
 
-        Assert.AreEqual(3, tabIn.Tabs.Count);
-        Assert.AreEqual(tab1Name, tabIn.Tabs.ElementAt(0).Text);
-        Assert.AreEqual(tab2Name, tabIn.Tabs.ElementAt(1).Text);
-        Assert.AreEqual("Blarg", tabIn.Tabs.ElementAt(2).Text);
+        ClassicAssert.AreEqual(3, tabIn.Tabs.Count);
+        ClassicAssert.AreEqual(tab1Name, tabIn.Tabs.ElementAt(0).Text);
+        ClassicAssert.AreEqual(tab2Name, tabIn.Tabs.ElementAt(1).Text);
+        ClassicAssert.AreEqual("Blarg", tabIn.Tabs.ElementAt(2).Text);
     }
 
     [Test]
@@ -55,11 +55,11 @@ internal class AddTabOperationTests : Tests
             {
                 var op = new AddTabOperation(d, "  ");
                 op.Do();
-                Assert.AreEqual("blank", v.Tabs.ElementAt(2).Text);
+                ClassicAssert.AreEqual("blank", v.Tabs.ElementAt(2).Text);
             }, out _);
 
-        Assert.AreEqual(3, tabIn.Tabs.Count);
-        Assert.AreEqual("blank", tabIn.Tabs.ElementAt(2).Text);
+        ClassicAssert.AreEqual(3, tabIn.Tabs.Count);
+        ClassicAssert.AreEqual("blank", tabIn.Tabs.ElementAt(2).Text);
     }
 
     [Test]
@@ -72,14 +72,14 @@ internal class AddTabOperationTests : Tests
                 op.Do();
                 op = new AddTabOperation(d, "Blah");
                 op.Do();
-                Assert.AreEqual(4, v.Tabs.Count);
-                Assert.AreEqual("Blah", v.Tabs.ElementAt(2).Text);
-                Assert.AreEqual("Blah2", v.Tabs.ElementAt(3).Text);
+                ClassicAssert.AreEqual(4, v.Tabs.Count);
+                ClassicAssert.AreEqual("Blah", v.Tabs.ElementAt(2).Text);
+                ClassicAssert.AreEqual("Blah2", v.Tabs.ElementAt(3).Text);
             }, out _);
 
-        Assert.AreEqual(4, tabIn.Tabs.Count);
-        Assert.AreEqual("Blah", tabIn.Tabs.ElementAt(2).Text);
-        Assert.AreEqual("Blah2", tabIn.Tabs.ElementAt(3).Text);
+        ClassicAssert.AreEqual(4, tabIn.Tabs.Count);
+        ClassicAssert.AreEqual("Blah", tabIn.Tabs.ElementAt(2).Text);
+        ClassicAssert.AreEqual("Blah2", tabIn.Tabs.ElementAt(3).Text);
     }
 
     [Test]
@@ -91,29 +91,29 @@ internal class AddTabOperationTests : Tests
         var tabIn = RoundTrip<Toplevel, TabView>(
             (d, v) =>
             {
-                Assert.AreEqual(2, v.Tabs.Count, "Expected ViewFactory TabView to have a couple of example tabs when created");
+                ClassicAssert.AreEqual(2, v.Tabs.Count, "Expected ViewFactory TabView to have a couple of example tabs when created");
                 tab1Name = v.Tabs.ElementAt(0).Text.ToString();
                 tab2Name = v.Tabs.ElementAt(1).Text.ToString();
 
                 var op = new AddTabOperation(d, "Blarg");
-                Assert.AreEqual(2, v.Tabs.Count, "Operation has not been run so why are there new tabs!");
-                Assert.AreEqual(tab1Name, v.Tabs.ElementAt(0).Text);
-                Assert.AreEqual(tab2Name, v.Tabs.ElementAt(1).Text);
+                ClassicAssert.AreEqual(2, v.Tabs.Count, "Operation has not been run so why are there new tabs!");
+                ClassicAssert.AreEqual(tab1Name, v.Tabs.ElementAt(0).Text);
+                ClassicAssert.AreEqual(tab2Name, v.Tabs.ElementAt(1).Text);
 
                 op.Do();
-                Assert.AreEqual(3, v.Tabs.Count);
-                Assert.AreEqual("Blarg", v.Tabs.ElementAt(2).Text);
-                Assert.AreEqual(tab1Name, v.Tabs.ElementAt(0).Text);
-                Assert.AreEqual(tab2Name, v.Tabs.ElementAt(1).Text);
+                ClassicAssert.AreEqual(3, v.Tabs.Count);
+                ClassicAssert.AreEqual("Blarg", v.Tabs.ElementAt(2).Text);
+                ClassicAssert.AreEqual(tab1Name, v.Tabs.ElementAt(0).Text);
+                ClassicAssert.AreEqual(tab2Name, v.Tabs.ElementAt(1).Text);
 
                 op.Undo();
-                Assert.AreEqual(tab1Name, v.Tabs.ElementAt(0).Text);
-                Assert.AreEqual(tab2Name, v.Tabs.ElementAt(1).Text);
-                Assert.AreEqual(2, v.Tabs.Count);
+                ClassicAssert.AreEqual(tab1Name, v.Tabs.ElementAt(0).Text);
+                ClassicAssert.AreEqual(tab2Name, v.Tabs.ElementAt(1).Text);
+                ClassicAssert.AreEqual(2, v.Tabs.Count);
             }, out _);
 
-        Assert.AreEqual(2, tabIn.Tabs.Count);
-        Assert.AreEqual(tab1Name, tabIn.Tabs.ElementAt(0).Text);
-        Assert.AreEqual(tab2Name, tabIn.Tabs.ElementAt(1).Text);
+        ClassicAssert.AreEqual(2, tabIn.Tabs.Count);
+        ClassicAssert.AreEqual(tab1Name, tabIn.Tabs.ElementAt(0).Text);
+        ClassicAssert.AreEqual(tab2Name, tabIn.Tabs.ElementAt(1).Text);
     }
 }

--- a/tests/Operations/AddViewOperationTests.cs
+++ b/tests/Operations/AddViewOperationTests.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using System.Linq;
 using Terminal.Gui;
 using TerminalGuiDesigner;
@@ -23,14 +23,14 @@ internal class AddViewOperationTests : Tests
             var op = new AddViewOperation(instance, d, "blah");
             op.Do();
 
-            Assert.AreEqual(
+            ClassicAssert.AreEqual(
                 stackSize, d.View.Subviews.Count,
                 "Expected the count of views to increase to match the number we have added");
 
-            Assert.AreSame(
+            ClassicAssert.AreSame(
                 instance, d.View.Subviews.Last(),
                 "Expected the view instance that was added to be the same we passed to operation constructor");
-            Assert.AreEqual(
+            ClassicAssert.AreEqual(
                 "blah" + (stackSize == 1 ? "" : stackSize.ToString()),
                 ((Design)d.View.Subviews.Last().Data).FieldName,
                 "Expected field name duplicates to be automatically resolved"
@@ -57,11 +57,11 @@ internal class AddViewOperationTests : Tests
             }
         }, out _);
 
-        Assert.AreEqual(stackSize, windowIn.GetActualSubviews().Count);
+        ClassicAssert.AreEqual(stackSize, windowIn.GetActualSubviews().Count);
 
         for (int i = 0; i < stackSize; i++)
         {
-            Assert.IsInstanceOf(supportedViews[i], windowIn.GetActualSubviews()[i]);
+            ClassicAssert.IsInstanceOf(supportedViews[i], windowIn.GetActualSubviews()[i]);
         }
     }
 
@@ -79,7 +79,7 @@ internal class AddViewOperationTests : Tests
             var instance = factory.Create(type);
             var op = new AddViewOperation(instance, d, "blah");
             OperationManager.Instance.Do(op);
-            Assert.AreEqual(
+            ClassicAssert.AreEqual(
                 stackSize, d.View.Subviews.Count,
                 "Expected the count of views to increase to match the number we have added");
         }
@@ -87,11 +87,11 @@ internal class AddViewOperationTests : Tests
         for (int i = 1; i <= stackSize; i++)
         {
             OperationManager.Instance.Undo();
-            Assert.AreEqual(
+            ClassicAssert.AreEqual(
                 stackSize-i, d.View.Subviews.Count,
                 "Expected the count of views to decrease once each time we Undo");
         }
 
-        Assert.IsEmpty(d.View.Subviews);
+        ClassicAssert.IsEmpty(d.View.Subviews);
     }
 }

--- a/tests/Operations/ConvertMenuItemToSeperatorOperationTests.cs
+++ b/tests/Operations/ConvertMenuItemToSeperatorOperationTests.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using Terminal.Gui;
 using TerminalGuiDesigner.Operations.MenuOperations;
 
@@ -11,23 +11,23 @@ internal class ConvertMenuItemToSeperatorOperationTests : Tests
     {
         var mbIn = RoundTrip<Toplevel, MenuBar>((d, v) =>
         {
-            Assert.AreEqual(1, v.Menus[0].Children.Length);
-            Assert.IsNotNull(v.Menus[0].Children[0]);
+            ClassicAssert.AreEqual(1, v.Menus[0].Children.Length);
+            ClassicAssert.IsNotNull(v.Menus[0].Children[0]);
 
             var op = new ConvertMenuItemToSeperatorOperation(v.Menus[0].Children[0]);
 
-            Assert.AreEqual(1, v.Menus[0].Children.Length);
-            Assert.IsNotNull(v.Menus[0].Children[0]);
+            ClassicAssert.AreEqual(1, v.Menus[0].Children.Length);
+            ClassicAssert.IsNotNull(v.Menus[0].Children[0]);
             op.Do();
 
-            Assert.AreEqual(1, v.Menus[0].Children.Length);
-            Assert.IsNull(v.Menus[0].Children[0]);
+            ClassicAssert.AreEqual(1, v.Menus[0].Children.Length);
+            ClassicAssert.IsNull(v.Menus[0].Children[0]);
 
         },out _);
 
 
-        Assert.AreEqual(1, mbIn.Menus[0].Children.Length);
-        Assert.IsNull(mbIn.Menus[0].Children[0]);
+        ClassicAssert.AreEqual(1, mbIn.Menus[0].Children.Length);
+        ClassicAssert.IsNull(mbIn.Menus[0].Children[0]);
     }
 
     [Test]
@@ -38,28 +38,28 @@ internal class ConvertMenuItemToSeperatorOperationTests : Tests
             var orig = v.Menus[0].Children[0];
             var op = new ConvertMenuItemToSeperatorOperation(orig);
             op.Do();
-            Assert.AreEqual(1, v.Menus[0].Children.Length);
-            Assert.IsNull(v.Menus[0].Children[0]);
+            ClassicAssert.AreEqual(1, v.Menus[0].Children.Length);
+            ClassicAssert.IsNull(v.Menus[0].Children[0]);
 
             op.Undo();
-            Assert.AreEqual(1, v.Menus[0].Children.Length);
-            Assert.AreSame(orig, v.Menus[0].Children[0]);
+            ClassicAssert.AreEqual(1, v.Menus[0].Children.Length);
+            ClassicAssert.AreSame(orig, v.Menus[0].Children[0]);
 
             op.Undo();
             op.Redo();
-            Assert.AreEqual(1, v.Menus[0].Children.Length);
-            Assert.IsNull(v.Menus[0].Children[0]);
+            ClassicAssert.AreEqual(1, v.Menus[0].Children.Length);
+            ClassicAssert.IsNull(v.Menus[0].Children[0]);
 
 
             op.Undo();
             op.Undo();
             op.Undo();
-            Assert.AreEqual(1, v.Menus[0].Children.Length);
-            Assert.AreSame(orig, v.Menus[0].Children[0]);
+            ClassicAssert.AreEqual(1, v.Menus[0].Children.Length);
+            ClassicAssert.AreSame(orig, v.Menus[0].Children[0]);
 
         }, out _);
 
-        Assert.AreEqual(1, mbIn.Menus[0].Children.Length);
-        Assert.IsNotNull(mbIn.Menus[0].Children[0]);
+        ClassicAssert.AreEqual(1, mbIn.Menus[0].Children.Length);
+        ClassicAssert.IsNotNull(mbIn.Menus[0].Children[0]);
     }
 }

--- a/tests/Operations/DeleteColorSchemeOperationTests.cs
+++ b/tests/Operations/DeleteColorSchemeOperationTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NUnit.Framework;
 using Terminal.Gui;
 using TerminalGuiDesigner;
@@ -20,11 +20,11 @@ internal class DeleteColorSchemeOperationTests : Tests
         {
             // Clear known default colors
             ColorSchemeManager.Instance.Clear();
-            Assert.IsEmpty(ColorSchemeManager.Instance.Schemes);
+            ClassicAssert.IsEmpty(ColorSchemeManager.Instance.Schemes);
 
             // Add a new color for our Label
             ColorSchemeManager.Instance.AddOrUpdateScheme("yarg", scheme, d.GetRootDesign());
-            Assert.AreEqual(1, ColorSchemeManager.Instance.Schemes.Count);
+            ClassicAssert.AreEqual(1, ColorSchemeManager.Instance.Schemes.Count);
 
             // Assign the new color to the view
             var prop = new SetPropertyOperation(d, new ColorSchemeProperty(d), null, scheme);
@@ -35,7 +35,7 @@ internal class DeleteColorSchemeOperationTests : Tests
 
         ColorSchemeManager.Instance.Clear();
         ColorSchemeManager.Instance.FindDeclaredColorSchemes(lblInDesign.GetRootDesign());
-        Assert.AreEqual(1, ColorSchemeManager.Instance.Schemes.Count, "Reloading the view should find the explicitly declared scheme 'yarg'");
+        ClassicAssert.AreEqual(1, ColorSchemeManager.Instance.Schemes.Count, "Reloading the view should find the explicitly declared scheme 'yarg'");
 
         var rootDesignIn = lblInDesign.GetRootDesign();
 
@@ -48,11 +48,11 @@ internal class DeleteColorSchemeOperationTests : Tests
         var yarg = ColorSchemeManager.Instance.GetNamedColorScheme("yarg");
         var deleteOp = new DeleteColorSchemeOperation(rootDesignIn, yarg);
 
-        Assert.IsTrue(deleteOp.Do());
+        ClassicAssert.IsTrue(deleteOp.Do());
 
         // after deleting the color scheme nobody should be using it
-        Assert.IsNull(lblIn.GetExplicitColorScheme());
-        Assert.IsNull(lblInDesign.State.OriginalScheme);
+        ClassicAssert.IsNull(lblIn.GetExplicitColorScheme());
+        ClassicAssert.IsNull(lblInDesign.State.OriginalScheme);
 
         // throw a curve ball, all these should do nothing
         deleteOp.Do();
@@ -63,13 +63,13 @@ internal class DeleteColorSchemeOperationTests : Tests
         // after redoing the operation we should be back to using it again
         deleteOp.Undo();
 
-        Assert.AreEqual(
+        ClassicAssert.AreEqual(
             "yarg",
             ColorSchemeManager.Instance.GetNameForColorScheme(
             lblIn.GetExplicitColorScheme() ?? throw new Exception("Expected lblIn to have the scheme again")),
             "Expected designer to still know the name of lblIn ColorScheme");
 
-        Assert.AreEqual(yarg.Scheme, lblIn.GetExplicitColorScheme() ?? throw new Exception("View was unexpected no longer using our color scheme after Redo"));
-        Assert.AreEqual(yarg.Scheme, lblInDesign.State.OriginalScheme ?? throw new Exception("View was unexpected no longer using our color scheme after Redo"));
+        ClassicAssert.AreEqual(yarg.Scheme, lblIn.GetExplicitColorScheme() ?? throw new Exception("View was unexpected no longer using our color scheme after Redo"));
+        ClassicAssert.AreEqual(yarg.Scheme, lblInDesign.State.OriginalScheme ?? throw new Exception("View was unexpected no longer using our color scheme after Redo"));
     }
 }

--- a/tests/Operations/DeleteViewOperationTests.cs
+++ b/tests/Operations/DeleteViewOperationTests.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Linq;
 using NUnit.Framework;
 using Terminal.Gui;
@@ -27,13 +27,13 @@ internal class DeleteViewOperationTests : Tests
         new AddViewOperation(lbl2, designOut, "lbl2").Do();
 
         // not impossible, we could totally delete either of these
-        Assert.IsFalse(new DeleteViewOperation((Design)lbl1.Data).IsImpossible);
-        Assert.IsFalse(new DeleteViewOperation((Design)lbl2.Data).IsImpossible);
+        ClassicAssert.IsFalse(new DeleteViewOperation((Design)lbl1.Data).IsImpossible);
+        ClassicAssert.IsFalse(new DeleteViewOperation((Design)lbl2.Data).IsImpossible);
 
         // we now have a dependency of lbl2 on lbl1 so deleting lbl1 will go badly
         lbl2.X = Pos.Right(lbl1) + 5;
 
-        Assert.IsTrue(new DeleteViewOperation((Design)lbl1.Data).IsImpossible);
+        ClassicAssert.IsTrue(new DeleteViewOperation((Design)lbl1.Data).IsImpossible);
     }
 
     [Test]
@@ -56,16 +56,16 @@ internal class DeleteViewOperationTests : Tests
         lbl2.X = Pos.Right(lbl1) + 5;
 
         // Deleting both at once should be possible since there are no hanging references
-        Assert.IsFalse(new DeleteViewOperation((Design)lbl1.Data, (Design)lbl2.Data).IsImpossible);
-        Assert.IsFalse(new DeleteViewOperation((Design)lbl2.Data, (Design)lbl1.Data).IsImpossible);
+        ClassicAssert.IsFalse(new DeleteViewOperation((Design)lbl1.Data, (Design)lbl2.Data).IsImpossible);
+        ClassicAssert.IsFalse(new DeleteViewOperation((Design)lbl2.Data, (Design)lbl1.Data).IsImpossible);
 
-        Assert.AreEqual(3, designOut.GetAllDesigns().Count());
+        ClassicAssert.AreEqual(3, designOut.GetAllDesigns().Count());
         var cmd = new DeleteViewOperation((Design)lbl2.Data, (Design)lbl1.Data);
-        Assert.IsTrue(cmd.Do());
-        Assert.AreEqual(1, designOut.GetAllDesigns().Count());
+        ClassicAssert.IsTrue(cmd.Do());
+        ClassicAssert.AreEqual(1, designOut.GetAllDesigns().Count());
 
         cmd.Undo();
-        Assert.AreEqual(3, designOut.GetAllDesigns().Count());
+        ClassicAssert.AreEqual(3, designOut.GetAllDesigns().Count());
     }
 
     [TestCase(true)]
@@ -89,20 +89,20 @@ internal class DeleteViewOperationTests : Tests
         // normally commands are run with locked selection, lets run this test with both cases to be sure
         SelectionManager.Instance.LockSelection = lockSelection;
 
-        Assert.IsFalse(new DeleteViewOperation(lbl1Design).IsImpossible);
+        ClassicAssert.IsFalse(new DeleteViewOperation(lbl1Design).IsImpossible);
 
-        Assert.AreEqual(2, designOut.GetAllDesigns().Count());
+        ClassicAssert.AreEqual(2, designOut.GetAllDesigns().Count());
         var cmd = new DeleteViewOperation(lbl1Design);
 
-        Assert.Contains(lbl1Design, SelectionManager.Instance.Selected.ToArray());
+        ClassicAssert.Contains(lbl1Design, SelectionManager.Instance.Selected.ToArray());
 
-        Assert.IsTrue(cmd.Do());
-        Assert.AreEqual(1, designOut.GetAllDesigns().Count());
+        ClassicAssert.IsTrue(cmd.Do());
+        ClassicAssert.AreEqual(1, designOut.GetAllDesigns().Count());
 
-        Assert.IsEmpty(SelectionManager.Instance.Selected.ToArray(), "Deleting the view should remove it from the active selection");
+        ClassicAssert.IsEmpty(SelectionManager.Instance.Selected.ToArray(), "Deleting the view should remove it from the active selection");
 
         cmd.Undo();
-        Assert.AreEqual(2, designOut.GetAllDesigns().Count());
-        Assert.Contains(lbl1Design, SelectionManager.Instance.Selected.ToArray(), "Undoing a delete operation should restore the previous selection");
+        ClassicAssert.AreEqual(2, designOut.GetAllDesigns().Count());
+        ClassicAssert.Contains(lbl1Design, SelectionManager.Instance.Selected.ToArray(), "Undoing a delete operation should restore the previous selection");
     }
 }

--- a/tests/Operations/DragOperationTests.cs
+++ b/tests/Operations/DragOperationTests.cs
@@ -32,18 +32,18 @@ internal class DragOperationTests : Tests
 
         // drag down 3 lines
         drag.ContinueDrag(new Point(2, 3));
-        Assert.AreEqual(Pos.At(0), lbl.X);
-        Assert.AreEqual(Pos.At(3), lbl.Y);
+        ClassicAssert.AreEqual(Pos.At(0), lbl.X);
+        ClassicAssert.AreEqual(Pos.At(3), lbl.Y);
 
         // finalise the operation
         drag.Do();
-        Assert.AreEqual(Pos.At(0), lbl.X);
-        Assert.AreEqual(Pos.At(3), lbl.Y);
+        ClassicAssert.AreEqual(Pos.At(0), lbl.X);
+        ClassicAssert.AreEqual(Pos.At(3), lbl.Y);
 
         // now test undoing it
         drag.Undo();
-        Assert.AreEqual(Pos.At(0), lbl.X);
-        Assert.AreEqual(Pos.At(0), lbl.Y);
+        ClassicAssert.AreEqual(Pos.At(0), lbl.X);
+        ClassicAssert.AreEqual(Pos.At(0), lbl.Y);
     }
 
     /// <summary>
@@ -66,13 +66,13 @@ internal class DragOperationTests : Tests
         MouseDrag(d, 2, 0, 2, 3);
 
         // finalize the operation
-        Assert.AreEqual(Pos.At(0), lbl.X);
-        Assert.AreEqual(Pos.At(3), lbl.Y);
+        ClassicAssert.AreEqual(Pos.At(0), lbl.X);
+        ClassicAssert.AreEqual(Pos.At(3), lbl.Y);
 
         // now test undoing it
         OperationManager.Instance.Undo();
-        Assert.AreEqual(Pos.At(0), lbl.X);
-        Assert.AreEqual(Pos.At(0), lbl.Y);
+        ClassicAssert.AreEqual(Pos.At(0), lbl.X);
+        ClassicAssert.AreEqual(Pos.At(0), lbl.Y);
     }
 
 
@@ -100,24 +100,24 @@ internal class DragOperationTests : Tests
 
         // drag down 3 lines
         drag.ContinueDrag(new Point(2, 3));
-        Assert.AreEqual(Pos.At(0), lbl1.X);
-        Assert.AreEqual(Pos.At(3), lbl1.Y);
-        Assert.AreEqual(Pos.At(1), lbl2.X);
-        Assert.AreEqual(Pos.At(4), lbl2.Y);
+        ClassicAssert.AreEqual(Pos.At(0), lbl1.X);
+        ClassicAssert.AreEqual(Pos.At(3), lbl1.Y);
+        ClassicAssert.AreEqual(Pos.At(1), lbl2.X);
+        ClassicAssert.AreEqual(Pos.At(4), lbl2.Y);
 
         // finalize the operation
         drag.Do();
-        Assert.AreEqual(Pos.At(0), lbl1.X);
-        Assert.AreEqual(Pos.At(3), lbl1.Y);
-        Assert.AreEqual(Pos.At(1), lbl2.X);
-        Assert.AreEqual(Pos.At(4), lbl2.Y);
+        ClassicAssert.AreEqual(Pos.At(0), lbl1.X);
+        ClassicAssert.AreEqual(Pos.At(3), lbl1.Y);
+        ClassicAssert.AreEqual(Pos.At(1), lbl2.X);
+        ClassicAssert.AreEqual(Pos.At(4), lbl2.Y);
 
         // now test undoing it
         drag.Undo();
-        Assert.AreEqual(Pos.At(0), lbl1.X);
-        Assert.AreEqual(Pos.At(0), lbl1.Y);
-        Assert.AreEqual(Pos.At(1), lbl2.X);
-        Assert.AreEqual(Pos.At(1), lbl2.Y);
+        ClassicAssert.AreEqual(Pos.At(0), lbl1.X);
+        ClassicAssert.AreEqual(Pos.At(0), lbl1.Y);
+        ClassicAssert.AreEqual(Pos.At(1), lbl2.X);
+        ClassicAssert.AreEqual(Pos.At(1), lbl2.Y);
     }
 
     [Test]
@@ -146,17 +146,17 @@ internal class DragOperationTests : Tests
 
         // In client coordinate system of container1 we have not moved the mouse
         // anywhere so the drag will not take the View to anywhere
-        Assert.AreEqual(1, drag.DestinationX);
-        Assert.AreEqual(2, drag.DestinationY);
+        ClassicAssert.AreEqual(1, drag.DestinationX);
+        ClassicAssert.AreEqual(2, drag.DestinationY);
 
         drag.ContinueDrag(new Point(2, 3));
 
-        Assert.AreEqual(2, drag.DestinationX);
-        Assert.AreEqual(3, drag.DestinationY);
+        ClassicAssert.AreEqual(2, drag.DestinationX);
+        ClassicAssert.AreEqual(3, drag.DestinationY);
         drag.Do();
 
-        Assert.AreEqual(Pos.At(2), lbl.X);
-        Assert.AreEqual(Pos.At(3), lbl.Y);
+        ClassicAssert.AreEqual(Pos.At(2), lbl.X);
+        ClassicAssert.AreEqual(Pos.At(3), lbl.Y);
     }
 
     [Test]
@@ -199,22 +199,22 @@ internal class DragOperationTests : Tests
         drag.ContinueDrag(new Point(6, 7));
         drag.DropInto = container2;
 
-        Assert.AreEqual(Pos.At(4), lbl.X);
-        Assert.AreEqual(Pos.At(7), lbl.Y);
-        Assert.Contains(lbl, container1.Subviews.ToArray(), "Did not expect continue drag to move to a new container");
+        ClassicAssert.AreEqual(Pos.At(4), lbl.X);
+        ClassicAssert.AreEqual(Pos.At(7), lbl.Y);
+        ClassicAssert.Contains(lbl, container1.Subviews.ToArray(), "Did not expect continue drag to move to a new container");
 
         // finalise the operation
         drag.Do();
-        Assert.IsFalse(container1.Subviews.Contains(lbl));
-        Assert.Contains(lbl, container2.Subviews.ToArray(), "Expected new container to be the one we dropped into");
-        Assert.AreEqual(Pos.At(-1), lbl.X);
-        Assert.AreEqual(Pos.At(2), lbl.Y);
+        ClassicAssert.IsFalse(container1.Subviews.Contains(lbl));
+        ClassicAssert.Contains(lbl, container2.Subviews.ToArray(), "Expected new container to be the one we dropped into");
+        ClassicAssert.AreEqual(Pos.At(-1), lbl.X);
+        ClassicAssert.AreEqual(Pos.At(2), lbl.Y);
 
         // now test undoing it
         drag.Undo();
-        Assert.AreEqual(Pos.At(1), lbl.X);
-        Assert.AreEqual(Pos.At(2), lbl.Y);
-        Assert.Contains(lbl, container1.Subviews.ToArray(), "Expected undo to return view to its original parent");
+        ClassicAssert.AreEqual(Pos.At(1), lbl.X);
+        ClassicAssert.AreEqual(Pos.At(2), lbl.Y);
+        ClassicAssert.Contains(lbl, container1.Subviews.ToArray(), "Expected undo to return view to its original parent");
     }
 
     [Test]
@@ -227,8 +227,8 @@ internal class DragOperationTests : Tests
         rootDesign.View.ViewToScreenActual(0, 0, out var screenX, out var screenY);
 
         // A window is positioned at 0,0 but its client area (to which controls are added) is 1,1 due to border
-        Assert.AreEqual(1, screenX);
-        Assert.AreEqual(1, screenY);
+        ClassicAssert.AreEqual(1, screenX);
+        ClassicAssert.AreEqual(1, screenY);
 
         var frameView = new ViewFactory().Create(typeof(FrameView));
         frameView.X = 10;
@@ -242,8 +242,8 @@ internal class DragOperationTests : Tests
         /*Window client area starts at (1,1) + (10,10 X/Y) + (1,1) for border of FrameView*/
 
         frameView.ViewToScreenActual(0, 0, out screenX, out screenY);
-        Assert.AreEqual(12, screenX);
-        Assert.AreEqual(12, screenY);
+        ClassicAssert.AreEqual(12, screenX);
+        ClassicAssert.AreEqual(12, screenY);
 
         var lbl = new Label(1, 2, "Hi there buddy");
         var lblDesign = new Design(rootDesign.SourceCode, "mylabel", lbl);
@@ -255,11 +255,11 @@ internal class DragOperationTests : Tests
 
         // check screen coordinates are as expected
         lblDesign.View.ViewToScreenActual(0, 0, out screenX, out screenY);
-        Assert.AreEqual(13, screenX, "Expected label X screen to be at its parents 0,0 (11,11) + 1");
-        Assert.AreEqual(14, screenY, "Expected label Y screen to be at its parents 0,0 (11,11) + 2");
+        ClassicAssert.AreEqual(13, screenX, "Expected label X screen to be at its parents 0,0 (11,11) + 1");
+        ClassicAssert.AreEqual(14, screenY, "Expected label Y screen to be at its parents 0,0 (11,11) + 2");
 
         // press down at 0,0 of the label
-        Assert.AreEqual(lbl, rootDesign.View.HitTest(new MouseEvent { X = 13, Y = 14 }, out _, out _)
+        ClassicAssert.AreEqual(lbl, rootDesign.View.HitTest(new MouseEvent { X = 13, Y = 14 }, out _, out _)
             , "We just asked ViewToScreen for these same coordinates, how can they fail HitTest now?");
 
         // Drag up 4 so it is no longer in its parents container.
@@ -269,8 +269,8 @@ internal class DragOperationTests : Tests
         MouseDrag(rootDesign, 13, 14, 13, 10);
 
 
-        Assert.False(frameView.GetActualSubviews().Contains(lbl), "Expected label to no longer be in the scroll view");
-        Assert.Contains(lblDesign.View, rootDesign.View.GetActualSubviews().ToArray(), "Expected label to have moved to the parent Window");
+        ClassicAssert.False(frameView.GetActualSubviews().Contains(lbl), "Expected label to no longer be in the scroll view");
+        ClassicAssert.Contains(lblDesign.View, rootDesign.View.GetActualSubviews().ToArray(), "Expected label to have moved to the parent Window");
     }
 
     [Test]
@@ -290,13 +290,13 @@ internal class DragOperationTests : Tests
             Application.Top.LayoutSubviews();
 
 
-            Assert.AreEqual(0, v.Tabs.ElementAt(0).View.GetActualSubviews().Count, "Expected TabView Tab1 to start off empty");
+            ClassicAssert.AreEqual(0, v.Tabs.ElementAt(0).View.GetActualSubviews().Count, "Expected TabView Tab1 to start off empty");
 
             // Drag the Button into the TabView
             MouseDrag(d.GetRootDesign(), 0, 0, 3, 3);
 
-            Assert.AreEqual(1, v.Tabs.ElementAt(0).View.GetActualSubviews().Count, "Expected TabView Tab1 to now contain Button");
-            Assert.IsInstanceOf<Button>(v.Tabs.ElementAt(0).View.GetActualSubviews().Single());
+            ClassicAssert.AreEqual(1, v.Tabs.ElementAt(0).View.GetActualSubviews().Count, "Expected TabView Tab1 to now contain Button");
+            ClassicAssert.IsInstanceOf<Button>(v.Tabs.ElementAt(0).View.GetActualSubviews().Single());
 
         }, out _);
     }

--- a/tests/Operations/MoveColumnOperationTests.cs
+++ b/tests/Operations/MoveColumnOperationTests.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using System;
 using Terminal.Gui;
 using TerminalGuiDesigner;
@@ -14,7 +14,7 @@ internal class MoveColumnOperationTests : Tests
         // Label is not a TableView so should get Exception
         RoundTrip<Window, Label>((d, v) =>
         {
-            Assert.Throws<ArgumentException>(()=>new MoveColumnOperation(d,new System.Data.DataColumn(), 1));
+            ClassicAssert.Throws<ArgumentException>(()=>new MoveColumnOperation(d,new System.Data.DataColumn(), 1));
         }, out _);
     }
 
@@ -25,7 +25,7 @@ internal class MoveColumnOperationTests : Tests
         RoundTrip<Window, TableView>((d, v) =>
         {
             // DataColumn is new and not in v.Table
-            Assert.Throws<ArgumentException>(() =>
+            ClassicAssert.Throws<ArgumentException>(() =>
                 new MoveColumnOperation(d, new System.Data.DataColumn(), 1));
         }, out _);
     }
@@ -36,13 +36,13 @@ internal class MoveColumnOperationTests : Tests
     {
         RoundTrip<Window, TableView>((d, v) =>
         {
-            Assert.AreEqual(4, v.Table.Columns.Count, $"Expected {nameof(ViewFactory)} to create a {nameof(TableView)} with 4 example placeholder Columns");
+            ClassicAssert.AreEqual(4, v.Table.Columns.Count, $"Expected {nameof(ViewFactory)} to create a {nameof(TableView)} with 4 example placeholder Columns");
             v.Table.Columns.RemoveAt(1);
             v.Table.Columns.RemoveAt(1);
             v.Table.Columns.RemoveAt(1);
-            Assert.AreEqual(1, v.Table.Columns.Count);
+            ClassicAssert.AreEqual(1, v.Table.Columns.Count);
 
-            Assert.IsTrue(new MoveColumnOperation(d, v.Table.Columns[0],1).IsImpossible,"Should be impossible to move Column when there is only one of them");
+            ClassicAssert.IsTrue(new MoveColumnOperation(d, v.Table.Columns[0],1).IsImpossible,"Should be impossible to move Column when there is only one of them");
         }, out _);
     }
 
@@ -55,7 +55,7 @@ internal class MoveColumnOperationTests : Tests
     {
         RoundTrip<Window, TableView>((d, v) =>
         {
-            Assert.AreEqual(4, v.Table.Columns.Count, $"Expected {nameof(ViewFactory)} to create a {nameof(TableView)} with 4 example placeholder Columns");
+            ClassicAssert.AreEqual(4, v.Table.Columns.Count, $"Expected {nameof(ViewFactory)} to create a {nameof(TableView)} with 4 example placeholder Columns");
 
             var toMove = v.Table.Columns[idxToMove];
             var originalIndex = toMove.Ordinal;
@@ -64,22 +64,22 @@ internal class MoveColumnOperationTests : Tests
 
             if(expectPossible)
             {
-                Assert.IsFalse(op.IsImpossible);
-                Assert.IsTrue(op.Do());
+                ClassicAssert.IsFalse(op.IsImpossible);
+                ClassicAssert.IsTrue(op.Do());
             }
             else
             {
-                Assert.IsTrue(op.IsImpossible);
-                Assert.False(op.Do());
+                ClassicAssert.IsTrue(op.IsImpossible);
+                ClassicAssert.False(op.Do());
             }
 
-            Assert.AreEqual(expectedNewIndex, toMove.Ordinal);
+            ClassicAssert.AreEqual(expectedNewIndex, toMove.Ordinal);
 
             op.Undo();
-            Assert.AreEqual(originalIndex, toMove.Ordinal);
+            ClassicAssert.AreEqual(originalIndex, toMove.Ordinal);
 
             op.Redo();
-            Assert.AreEqual(expectedNewIndex, toMove.Ordinal);
+            ClassicAssert.AreEqual(expectedNewIndex, toMove.Ordinal);
 
         }, out _);
     }

--- a/tests/Operations/MoveMenuItemLeftOperationTests.cs
+++ b/tests/Operations/MoveMenuItemLeftOperationTests.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using Terminal.Gui;
 using TerminalGuiDesigner;
 using TerminalGuiDesigner.Operations.MenuOperations;
@@ -13,8 +13,8 @@ internal class MoveMenuItemLeftOperationTests : Tests
         RoundTrip<Toplevel, MenuBar>((d,v)=>
         {
             var op = new MoveMenuItemLeftOperation(v.Menus[0].Children[0]);
-            Assert.IsTrue(op.IsImpossible, "Expected it to be impossible to move left a menu that is under a root MenuBar Item (e.g. items under File, Edit, View etc)");
-            Assert.IsFalse(op.Do());
+            ClassicAssert.IsTrue(op.IsImpossible, "Expected it to be impossible to move left a menu that is under a root MenuBar Item (e.g. items under File, Edit, View etc)");
+            ClassicAssert.IsFalse(op.Do());
         }
         ,out _);
     }
@@ -26,8 +26,8 @@ internal class MoveMenuItemLeftOperationTests : Tests
         var haha = new MenuItem(); 
 
         var op = new MoveMenuItemLeftOperation(haha);
-        Assert.IsTrue(op.IsImpossible, "Expected it to be impossible to move left a menu that is under a root MenuBar Item (e.g. items under File, Edit, View etc)");
-        Assert.IsFalse(op.Do());
+        ClassicAssert.IsTrue(op.IsImpossible, "Expected it to be impossible to move left a menu that is under a root MenuBar Item (e.g. items under File, Edit, View etc)");
+        ClassicAssert.IsFalse(op.Do());
     }
 
     [TestCase(0)]
@@ -37,23 +37,23 @@ internal class MoveMenuItemLeftOperationTests : Tests
     {
         var mb = GetDeepMenu();
 
-        Assert.IsInstanceOf<MenuBarItem>(mb.Menus[0].Children[0]);
-        Assert.AreEqual("File", mb.Menus[0].Title.ToString());
-        Assert.AreEqual("New", ((MenuBarItem)mb.Menus[0].Children[0]).Title.ToString());
-        Assert.AreEqual("Document", ((MenuBarItem)mb.Menus[0].Children[0]).Children[0].Title.ToString());
-        Assert.AreEqual("Spreadsheet", ((MenuBarItem)mb.Menus[0].Children[0]).Children[1].Title.ToString());
-        Assert.AreEqual("Video Game", ((MenuBarItem)mb.Menus[0].Children[0]).Children[2].Title.ToString());
+        ClassicAssert.IsInstanceOf<MenuBarItem>(mb.Menus[0].Children[0]);
+        ClassicAssert.AreEqual("File", mb.Menus[0].Title.ToString());
+        ClassicAssert.AreEqual("New", ((MenuBarItem)mb.Menus[0].Children[0]).Title.ToString());
+        ClassicAssert.AreEqual("Document", ((MenuBarItem)mb.Menus[0].Children[0]).Children[0].Title.ToString());
+        ClassicAssert.AreEqual("Spreadsheet", ((MenuBarItem)mb.Menus[0].Children[0]).Children[1].Title.ToString());
+        ClassicAssert.AreEqual("Video Game", ((MenuBarItem)mb.Menus[0].Children[0]).Children[2].Title.ToString());
 
         var op = new MoveMenuItemLeftOperation(((MenuBarItem)mb.Menus[0].Children[0]).Children[indexToMove]);
-        Assert.IsFalse(op.IsImpossible);
-        Assert.IsTrue(op.Do());
-        Assert.AreEqual(2, ((MenuBarItem)mb.Menus[0].Children[0]).Children.Length);
+        ClassicAssert.IsFalse(op.IsImpossible);
+        ClassicAssert.IsTrue(op.Do());
+        ClassicAssert.AreEqual(2, ((MenuBarItem)mb.Menus[0].Children[0]).Children.Length);
 
-        Assert.IsInstanceOf<MenuBarItem>(mb.Menus[0].Children[0], "Expected the New sub-menu drop-down to still be there");
-        Assert.IsInstanceOf<MenuItem>(mb.Menus[0].Children[1], "Expected our pulled up menu item to now be on root and under sub-menu");
+        ClassicAssert.IsInstanceOf<MenuBarItem>(mb.Menus[0].Children[0], "Expected the New sub-menu drop-down to still be there");
+        ClassicAssert.IsInstanceOf<MenuItem>(mb.Menus[0].Children[1], "Expected our pulled up menu item to now be on root and under sub-menu");
 
 
-        Assert.AreEqual(
+        ClassicAssert.AreEqual(
             indexToMove switch
             {
                 0 => "Document",
@@ -66,12 +66,12 @@ internal class MoveMenuItemLeftOperationTests : Tests
         op.Undo();
 
         // should now be back to the way we were before applying operation
-        Assert.IsInstanceOf<MenuBarItem>(mb.Menus[0].Children[0]);
-        Assert.AreEqual("File", mb.Menus[0].Title.ToString());
-        Assert.AreEqual("New", ((MenuBarItem)mb.Menus[0].Children[0]).Title.ToString());
-        Assert.AreEqual("Document", ((MenuBarItem)mb.Menus[0].Children[0]).Children[0].Title.ToString());
-        Assert.AreEqual("Spreadsheet", ((MenuBarItem)mb.Menus[0].Children[0]).Children[1].Title.ToString());
-        Assert.AreEqual("Video Game", ((MenuBarItem)mb.Menus[0].Children[0]).Children[2].Title.ToString());
+        ClassicAssert.IsInstanceOf<MenuBarItem>(mb.Menus[0].Children[0]);
+        ClassicAssert.AreEqual("File", mb.Menus[0].Title.ToString());
+        ClassicAssert.AreEqual("New", ((MenuBarItem)mb.Menus[0].Children[0]).Title.ToString());
+        ClassicAssert.AreEqual("Document", ((MenuBarItem)mb.Menus[0].Children[0]).Children[0].Title.ToString());
+        ClassicAssert.AreEqual("Spreadsheet", ((MenuBarItem)mb.Menus[0].Children[0]).Children[1].Title.ToString());
+        ClassicAssert.AreEqual("Video Game", ((MenuBarItem)mb.Menus[0].Children[0]).Children[2].Title.ToString());
     }
     
     [Test]
@@ -79,12 +79,12 @@ internal class MoveMenuItemLeftOperationTests : Tests
     {
         var mb = GetDeepMenu();
 
-        Assert.IsInstanceOf<MenuBarItem>(mb.Menus[0].Children[0]);
-        Assert.AreEqual("File", mb.Menus[0].Title.ToString());
-        Assert.AreEqual("New", ((MenuBarItem)mb.Menus[0].Children[0]).Title.ToString());
-        Assert.AreEqual("Document", ((MenuBarItem)mb.Menus[0].Children[0]).Children[0].Title.ToString());
-        Assert.AreEqual("Spreadsheet", ((MenuBarItem)mb.Menus[0].Children[0]).Children[1].Title.ToString());
-        Assert.AreEqual("Video Game", ((MenuBarItem)mb.Menus[0].Children[0]).Children[2].Title.ToString());
+        ClassicAssert.IsInstanceOf<MenuBarItem>(mb.Menus[0].Children[0]);
+        ClassicAssert.AreEqual("File", mb.Menus[0].Title.ToString());
+        ClassicAssert.AreEqual("New", ((MenuBarItem)mb.Menus[0].Children[0]).Title.ToString());
+        ClassicAssert.AreEqual("Document", ((MenuBarItem)mb.Menus[0].Children[0]).Children[0].Title.ToString());
+        ClassicAssert.AreEqual("Spreadsheet", ((MenuBarItem)mb.Menus[0].Children[0]).Children[1].Title.ToString());
+        ClassicAssert.AreEqual("Video Game", ((MenuBarItem)mb.Menus[0].Children[0]).Children[2].Title.ToString());
 
         // Setup operations to remove all 3
         var op1 = new MoveMenuItemLeftOperation(((MenuBarItem)mb.Menus[0].Children[0]).Children[0]);
@@ -92,17 +92,17 @@ internal class MoveMenuItemLeftOperationTests : Tests
         var op3 = new MoveMenuItemLeftOperation(((MenuBarItem)mb.Menus[0].Children[0]).Children[2]);
 
         op1.Do();
-        Assert.IsInstanceOf<MenuBarItem>(mb.Menus[0].Children[0], "Expected the New sub-menu drop-down to still be there");
-        Assert.AreEqual(2,((MenuBarItem)mb.Menus[0].Children[0]).Children.Length);
+        ClassicAssert.IsInstanceOf<MenuBarItem>(mb.Menus[0].Children[0], "Expected the New sub-menu drop-down to still be there");
+        ClassicAssert.AreEqual(2,((MenuBarItem)mb.Menus[0].Children[0]).Children.Length);
         op2.Do();
-        Assert.IsInstanceOf<MenuBarItem>(mb.Menus[0].Children[0], "Expected the New sub-menu drop-down to still be there");
-        Assert.AreEqual(1, ((MenuBarItem)mb.Menus[0].Children[0]).Children.Length);
+        ClassicAssert.IsInstanceOf<MenuBarItem>(mb.Menus[0].Children[0], "Expected the New sub-menu drop-down to still be there");
+        ClassicAssert.AreEqual(1, ((MenuBarItem)mb.Menus[0].Children[0]).Children.Length);
         op3.Do();
-        Assert.IsInstanceOf<MenuItem>(mb.Menus[0].Children[0], "Expected New to convert to a MenuItem (have no drop-down) once last drop-down item was moved out");
+        ClassicAssert.IsInstanceOf<MenuItem>(mb.Menus[0].Children[0], "Expected New to convert to a MenuItem (have no drop-down) once last drop-down item was moved out");
 
         op3.Undo();
-        Assert.IsInstanceOf<MenuBarItem>(mb.Menus[0].Children[0], "Expected undo to restore 'New' MenuItem to a drop-down again");
-        Assert.AreEqual(1, ((MenuBarItem)mb.Menus[0].Children[0]).Children.Length);
+        ClassicAssert.IsInstanceOf<MenuBarItem>(mb.Menus[0].Children[0], "Expected undo to restore 'New' MenuItem to a drop-down again");
+        ClassicAssert.AreEqual(1, ((MenuBarItem)mb.Menus[0].Children[0]).Children.Length);
     }
     private MenuBar GetDeepMenu()
     {

--- a/tests/Operations/MoveMenuItemRightOperationTests.cs
+++ b/tests/Operations/MoveMenuItemRightOperationTests.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using Terminal.Gui;
 using TerminalGuiDesigner.Operations.MenuOperations;
 
@@ -12,7 +12,7 @@ internal class MoveMenuItemRightOperationTests : Tests
         RoundTrip<Toplevel, MenuBar>((d, v) =>
         {
             var op = new MoveMenuItemRightOperation(v.Menus[0].Children[0]);
-            Assert.True(op.IsImpossible, "Expected it to be impossible to move first menu item to submenu when there is nothing above it");
+            ClassicAssert.True(op.IsImpossible, "Expected it to be impossible to move first menu item to submenu when there is nothing above it");
 
         }, out _);
     }
@@ -25,21 +25,21 @@ internal class MoveMenuItemRightOperationTests : Tests
             new AddMenuItemOperation(v.Menus[0].Children[0]).Do();
 
 
-            Assert.IsTrue(
+            ClassicAssert.IsTrue(
                 new MoveMenuItemRightOperation(v.Menus[0].Children[0]).IsImpossible,
                 "Expected you still not to be able to move index 0 (because there is nothing above it)");
 
             var toMove = v.Menus[0].Children[1];
             var op = new MoveMenuItemRightOperation(toMove);
-            Assert.IsFalse(op.IsImpossible);
+            ClassicAssert.IsFalse(op.IsImpossible);
 
-            Assert.AreEqual(2, v.Menus[0].Children.Length);
-            Assert.IsInstanceOf<MenuItem>(v.Menus[0].Children[0]);
+            ClassicAssert.AreEqual(2, v.Menus[0].Children.Length);
+            ClassicAssert.IsInstanceOf<MenuItem>(v.Menus[0].Children[0]);
             op.Do();
 
-            Assert.AreEqual(1, v.Menus[0].Children.Length);
-            Assert.IsInstanceOf<MenuBarItem>(v.Menus[0].Children[0],"Expected top entry to be converted to the Type that has sub items");
-            Assert.Contains(toMove,((MenuBarItem)v.Menus[0].Children[0]).Children);
+            ClassicAssert.AreEqual(1, v.Menus[0].Children.Length);
+            ClassicAssert.IsInstanceOf<MenuBarItem>(v.Menus[0].Children[0],"Expected top entry to be converted to the Type that has sub items");
+            ClassicAssert.Contains(toMove,((MenuBarItem)v.Menus[0].Children[0]).Children);
 
         }, out _);
     }
@@ -62,22 +62,22 @@ internal class MoveMenuItemRightOperationTests : Tests
             var op = new MoveMenuItemRightOperation(toMove);
             op.Do();
 
-            Assert.AreEqual("yarg", v.Menus[0].Children[0].Data);
-            Assert.AreEqual(Key.CtrlMask | Key.Y, v.Menus[0].Children[0].Shortcut);
-            Assert.AreEqual("blarg", ((MenuBarItem)v.Menus[0].Children[0]).Children[0].Data);
-            Assert.AreEqual(Key.CtrlMask | Key.B, ((MenuBarItem)v.Menus[0].Children[0]).Children[0].Shortcut);
+            ClassicAssert.AreEqual("yarg", v.Menus[0].Children[0].Data);
+            ClassicAssert.AreEqual(Key.CtrlMask | Key.Y, v.Menus[0].Children[0].Shortcut);
+            ClassicAssert.AreEqual("blarg", ((MenuBarItem)v.Menus[0].Children[0]).Children[0].Data);
+            ClassicAssert.AreEqual(Key.CtrlMask | Key.B, ((MenuBarItem)v.Menus[0].Children[0]).Children[0].Shortcut);
 
             op.Undo();
-            Assert.AreEqual("yarg", v.Menus[0].Children[0].Data);
-            Assert.AreEqual(Key.CtrlMask | Key.Y, v.Menus[0].Children[0].Shortcut);
-            Assert.AreEqual("blarg", v.Menus[0].Children[1].Data);
-            Assert.AreEqual(Key.CtrlMask | Key.B, v.Menus[0].Children[1].Shortcut);
+            ClassicAssert.AreEqual("yarg", v.Menus[0].Children[0].Data);
+            ClassicAssert.AreEqual(Key.CtrlMask | Key.Y, v.Menus[0].Children[0].Shortcut);
+            ClassicAssert.AreEqual("blarg", v.Menus[0].Children[1].Data);
+            ClassicAssert.AreEqual(Key.CtrlMask | Key.B, v.Menus[0].Children[1].Shortcut);
 
             op.Redo();
-            Assert.AreEqual("yarg", v.Menus[0].Children[0].Data);
-            Assert.AreEqual(Key.CtrlMask | Key.Y, v.Menus[0].Children[0].Shortcut);
-            Assert.AreEqual("blarg", ((MenuBarItem)v.Menus[0].Children[0]).Children[0].Data);
-            Assert.AreEqual(Key.CtrlMask | Key.B, ((MenuBarItem)v.Menus[0].Children[0]).Children[0].Shortcut);
+            ClassicAssert.AreEqual("yarg", v.Menus[0].Children[0].Data);
+            ClassicAssert.AreEqual(Key.CtrlMask | Key.Y, v.Menus[0].Children[0].Shortcut);
+            ClassicAssert.AreEqual("blarg", ((MenuBarItem)v.Menus[0].Children[0]).Children[0].Data);
+            ClassicAssert.AreEqual(Key.CtrlMask | Key.B, ((MenuBarItem)v.Menus[0].Children[0]).Children[0].Shortcut);
 
         }, out _);
     }

--- a/tests/Operations/MoveMenuOperationTests.cs
+++ b/tests/Operations/MoveMenuOperationTests.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using System;
 using System.Linq;
 using Terminal.Gui;
@@ -15,7 +15,7 @@ internal class MoveMenuOperationTests : Tests
         // Label is not a MenuBar so should get Exception
         RoundTrip<Window, Label>((d, v) =>
         {
-            Assert.Throws<ArgumentException>(()=>new MoveMenuOperation(d,new MenuBarItem(), 1));
+            ClassicAssert.Throws<ArgumentException>(()=>new MoveMenuOperation(d,new MenuBarItem(), 1));
         }, out _);
     }
 
@@ -25,7 +25,7 @@ internal class MoveMenuOperationTests : Tests
         RoundTrip<Window, MenuBar>((d, v) =>
         {
             // we passed a new MenuBarItem which will not belong to d and therefore should be an Exception
-            Assert.Throws<ArgumentException>(() => new MoveMenuOperation(d, new MenuBarItem(), 1));
+            ClassicAssert.Throws<ArgumentException>(() => new MoveMenuOperation(d, new MenuBarItem(), 1));
         }, out _);
     }
 
@@ -34,8 +34,8 @@ internal class MoveMenuOperationTests : Tests
     {
         RoundTrip<Window, MenuBar>((d, v) =>
         {
-            Assert.AreEqual(1, v.Menus.Length, $"Expected {nameof(ViewFactory)} to create a {nameof(MenuBar)} with 1 example placeholder Menu");
-            Assert.IsTrue(new MoveMenuOperation(d, v.Menus[0], 1).IsImpossible,"Should be impossible to move Menu when there is only one of them");
+            ClassicAssert.AreEqual(1, v.Menus.Length, $"Expected {nameof(ViewFactory)} to create a {nameof(MenuBar)} with 1 example placeholder Menu");
+            ClassicAssert.IsTrue(new MoveMenuOperation(d, v.Menus[0], 1).IsImpossible,"Should be impossible to move Menu when there is only one of them");
         }, out _);
     }
 
@@ -60,22 +60,22 @@ internal class MoveMenuOperationTests : Tests
 
             if(expectPossible)
             {
-                Assert.IsFalse(op.IsImpossible);
-                Assert.IsTrue(op.Do());
+                ClassicAssert.IsFalse(op.IsImpossible);
+                ClassicAssert.IsTrue(op.Do());
             }
             else
             {
-                Assert.IsTrue(op.IsImpossible);
-                Assert.False(op.Do());
+                ClassicAssert.IsTrue(op.IsImpossible);
+                ClassicAssert.False(op.Do());
             }
 
-            Assert.AreEqual(expectedNewIndex, v.Menus.IndexOf(toMove));
+            ClassicAssert.AreEqual(expectedNewIndex, v.Menus.IndexOf(toMove));
 
             op.Undo();
-            Assert.AreEqual(originalIndex, v.Menus.IndexOf(toMove));
+            ClassicAssert.AreEqual(originalIndex, v.Menus.IndexOf(toMove));
 
             op.Redo();
-            Assert.AreEqual(expectedNewIndex, v.Menus.IndexOf(toMove));
+            ClassicAssert.AreEqual(expectedNewIndex, v.Menus.IndexOf(toMove));
 
         }, out _);
     }

--- a/tests/Operations/MoveTabOperationTests.cs
+++ b/tests/Operations/MoveTabOperationTests.cs
@@ -15,7 +15,7 @@ internal class MoveTabOperationTests : Tests
         // Label is not a TabView so should get Exception
         RoundTrip<Window, Label>((d, v) =>
         {
-            Assert.Throws<ArgumentException>(()=>new MoveTabOperation(d,new TabView.Tab(), 1));
+            ClassicAssert.Throws<ArgumentException>(()=>new MoveTabOperation(d,new TabView.Tab(), 1));
         }, out _);
     }
 
@@ -24,11 +24,11 @@ internal class MoveTabOperationTests : Tests
     {
         RoundTrip<Window, TabView>((d, v) =>
         {
-            Assert.AreEqual(2, v.Tabs.Count, $"Expected {nameof(ViewFactory)} to create a {nameof(TabView)} with 2 example placeholder tabs");
+            ClassicAssert.AreEqual(2, v.Tabs.Count, $"Expected {nameof(ViewFactory)} to create a {nameof(TabView)} with 2 example placeholder tabs");
             v.RemoveTab(v.Tabs.ElementAt(1));
-            Assert.AreEqual(1, v.Tabs.Count);
+            ClassicAssert.AreEqual(1, v.Tabs.Count);
 
-            Assert.IsTrue(new MoveTabOperation(d, v.SelectedTab, 1).IsImpossible,"Should be impossible to move tab when there is only one of them");
+            ClassicAssert.IsTrue(new MoveTabOperation(d, v.SelectedTab, 1).IsImpossible,"Should be impossible to move tab when there is only one of them");
         }, out _);
     }
 
@@ -56,22 +56,22 @@ internal class MoveTabOperationTests : Tests
 
             if(expectPossible)
             {
-                Assert.IsFalse(op.IsImpossible);
-                Assert.IsTrue(op.Do());
+                ClassicAssert.IsFalse(op.IsImpossible);
+                ClassicAssert.IsTrue(op.Do());
             }
             else
             {
-                Assert.IsTrue(op.IsImpossible);
-                Assert.False(op.Do());
+                ClassicAssert.IsTrue(op.IsImpossible);
+                ClassicAssert.False(op.Do());
             }
 
-            Assert.AreEqual(expectedNewIndex, v.Tabs.IndexOf(toMove));
+            ClassicAssert.AreEqual(expectedNewIndex, v.Tabs.IndexOf(toMove));
 
             op.Undo();
-            Assert.AreEqual(originalIndex, v.Tabs.IndexOf(toMove));
+            ClassicAssert.AreEqual(originalIndex, v.Tabs.IndexOf(toMove));
 
             op.Redo();
-            Assert.AreEqual(expectedNewIndex, v.Tabs.IndexOf(toMove));
+            ClassicAssert.AreEqual(expectedNewIndex, v.Tabs.IndexOf(toMove));
 
         }, out _);
     }

--- a/tests/Operations/ResizeOperationTests.cs
+++ b/tests/Operations/ResizeOperationTests.cs
@@ -18,8 +18,8 @@ internal class ResizeOperationTests : Tests
             root.View.Height = Dim.Fill();
 
             root.View.ViewToScreenActual(0, 0, out var screenX, out var screenY);
-            Assert.AreEqual(1, screenX, "Expected root view of Dialog to have border 1 so client area starting at screen coordinates 1,1");
-            Assert.AreEqual(1, screenY);
+            ClassicAssert.AreEqual(1, screenX, "Expected root view of Dialog to have border 1 so client area starting at screen coordinates 1,1");
+            ClassicAssert.AreEqual(1, screenY);
 
 
             // within Dialog there is a View
@@ -52,14 +52,14 @@ internal class ResizeOperationTests : Tests
              * */
             // Double check the above figures
             v.ViewToScreenActual(0, 0, out screenX, out screenY);
-            Assert.AreEqual(4, screenX);
-            Assert.AreEqual(6, screenY);
+            ClassicAssert.AreEqual(4, screenX);
+            ClassicAssert.AreEqual(6, screenY);
             tab.ViewToScreenActual(0,0, out screenX, out screenY);
-            Assert.AreEqual(6, screenX);
-            Assert.AreEqual(7, screenY);
+            ClassicAssert.AreEqual(6, screenX);
+            ClassicAssert.AreEqual(7, screenY);
             tab.ViewToScreenActual(4, 4, out screenX, out screenY);
-            Assert.AreEqual(10, screenX);
-            Assert.AreEqual(11, screenY);
+            ClassicAssert.AreEqual(10, screenX);
+            ClassicAssert.AreEqual(11, screenY);
 
             Application.Begin((Dialog)root.View);
             root.View.LayoutSubviews();
@@ -75,14 +75,14 @@ internal class ResizeOperationTests : Tests
             else
             {
                 var hit = root.View.HitTest(new MouseEvent { X = 10, Y = 11 },out _, out var isLowerRight);
-                Assert.AreSame(tab, hit, "Expected above diagram which already passed asserts to work for HitTest too given the above screen coordinates");
-                Assert.IsTrue(isLowerRight);
+                ClassicAssert.AreSame(tab, hit, "Expected above diagram which already passed asserts to work for HitTest too given the above screen coordinates");
+                ClassicAssert.IsTrue(isLowerRight);
 
                 MouseDrag(root, 10, 11, 11, 13);
             }
 
-            Assert.AreEqual((Dim)6, tab.Width); // (5+1)
-            Assert.AreEqual((Dim)7, tab.Height); // (5+2)
+            ClassicAssert.AreEqual((Dim)6, tab.Width); // (5+1)
+            ClassicAssert.AreEqual((Dim)7, tab.Height); // (5+2)
         }, out _);
     }
 }

--- a/tests/PosTests.cs
+++ b/tests/PosTests.cs
@@ -15,53 +15,53 @@ internal class PosTests : Tests
     [Test]
     public void TestIsAbsolute()
     {
-        Assert.IsTrue(Pos.At(50).IsAbsolute());
-        Assert.IsFalse(Pos.At(50).IsPercent());
-        Assert.IsFalse(Pos.At(50).IsRelative());
-        Assert.IsFalse(Pos.At(50).IsAnchorEnd(out _));
+        ClassicAssert.IsTrue(Pos.At(50).IsAbsolute());
+        ClassicAssert.IsFalse(Pos.At(50).IsPercent());
+        ClassicAssert.IsFalse(Pos.At(50).IsRelative());
+        ClassicAssert.IsFalse(Pos.At(50).IsAnchorEnd(out _));
 
-        Assert.IsTrue(Pos.At(50).IsAbsolute(out int size));
-        Assert.AreEqual(50, size);
+        ClassicAssert.IsTrue(Pos.At(50).IsAbsolute(out int size));
+        ClassicAssert.AreEqual(50, size);
 
-        Assert.IsTrue(Pos.At(50).GetPosType(new List<Design>(), out var type, out var val, out var design, out var side, out var offset));
-        Assert.AreEqual(PosType.Absolute, type);
-        Assert.AreEqual(50, val);
-        Assert.AreEqual(0, offset);
+        ClassicAssert.IsTrue(Pos.At(50).GetPosType(new List<Design>(), out var type, out var val, out var design, out var side, out var offset));
+        ClassicAssert.AreEqual(PosType.Absolute, type);
+        ClassicAssert.AreEqual(50, val);
+        ClassicAssert.AreEqual(0, offset);
     }
 
     [Test]
     public void TestIsAbsolute_FromInt()
     {
         Pos p = 50;
-        Assert.IsTrue(p.IsAbsolute());
-        Assert.IsFalse(p.IsPercent());
-        Assert.IsFalse(p.IsRelative());
-        Assert.IsFalse(p.IsAnchorEnd(out _));
+        ClassicAssert.IsTrue(p.IsAbsolute());
+        ClassicAssert.IsFalse(p.IsPercent());
+        ClassicAssert.IsFalse(p.IsRelative());
+        ClassicAssert.IsFalse(p.IsAnchorEnd(out _));
 
-        Assert.IsTrue(p.IsAbsolute(out int size));
-        Assert.AreEqual(50, size);
+        ClassicAssert.IsTrue(p.IsAbsolute(out int size));
+        ClassicAssert.AreEqual(50, size);
 
-        Assert.IsTrue(p.GetPosType(new List<Design>(), out var type, out var val, out var design, out var side, out var offset));
-        Assert.AreEqual(PosType.Absolute, type);
-        Assert.AreEqual(50, val);
-        Assert.AreEqual(0, offset);
+        ClassicAssert.IsTrue(p.GetPosType(new List<Design>(), out var type, out var val, out var design, out var side, out var offset));
+        ClassicAssert.AreEqual(PosType.Absolute, type);
+        ClassicAssert.AreEqual(50, val);
+        ClassicAssert.AreEqual(0, offset);
     }
 
     [Test]
     public void TestIsPercent()
     {
-        Assert.IsFalse(Pos.Percent(24).IsAbsolute());
-        Assert.IsTrue(Pos.Percent(24).IsPercent());
-        Assert.IsFalse(Pos.Percent(24).IsRelative());
-        Assert.IsFalse(Pos.Percent(24).IsAnchorEnd(out _));
+        ClassicAssert.IsFalse(Pos.Percent(24).IsAbsolute());
+        ClassicAssert.IsTrue(Pos.Percent(24).IsPercent());
+        ClassicAssert.IsFalse(Pos.Percent(24).IsRelative());
+        ClassicAssert.IsFalse(Pos.Percent(24).IsAnchorEnd(out _));
 
-        Assert.IsTrue(Pos.Percent(24).IsPercent(out var size));
-        Assert.AreEqual(24f, size);
+        ClassicAssert.IsTrue(Pos.Percent(24).IsPercent(out var size));
+        ClassicAssert.AreEqual(24f, size);
 
-        Assert.IsTrue(Pos.Percent(24).GetPosType(new List<Design>(), out var type, out var val, out var design, out var side, out var offset));
-        Assert.AreEqual(PosType.Percent, type);
-        Assert.AreEqual(24, val);
-        Assert.AreEqual(0, offset);
+        ClassicAssert.IsTrue(Pos.Percent(24).GetPosType(new List<Design>(), out var type, out var val, out var design, out var side, out var offset));
+        ClassicAssert.AreEqual(PosType.Percent, type);
+        ClassicAssert.AreEqual(24, val);
+        ClassicAssert.AreEqual(0, offset);
     }
 
     [Test]
@@ -70,67 +70,67 @@ internal class PosTests : Tests
         View v = new View();
         var d = new Design(new SourceCodeFile(new FileInfo("yarg.cs")), "myView", v);
 
-        Assert.IsFalse(Pos.Top(v).IsAbsolute());
-        Assert.IsFalse(Pos.Top(v).IsPercent());
-        Assert.IsTrue(Pos.Top(v).IsRelative());
-        Assert.IsFalse(Pos.Top(v).IsAnchorEnd(out _));
+        ClassicAssert.IsFalse(Pos.Top(v).IsAbsolute());
+        ClassicAssert.IsFalse(Pos.Top(v).IsPercent());
+        ClassicAssert.IsTrue(Pos.Top(v).IsRelative());
+        ClassicAssert.IsFalse(Pos.Top(v).IsAnchorEnd(out _));
 
-        Assert.IsTrue(Pos.Top(v).IsRelative(new List<Design> { d }, out var relativeTo, out var side));
-        Assert.AreSame(d, relativeTo);
-        Assert.AreEqual(Side.Top, side);
+        ClassicAssert.IsTrue(Pos.Top(v).IsRelative(new List<Design> { d }, out var relativeTo, out var side));
+        ClassicAssert.AreSame(d, relativeTo);
+        ClassicAssert.AreEqual(Side.Top, side);
 
-        Assert.IsTrue(Pos.Top(v).GetPosType(new List<Design> { d }, out var type, out var val, out relativeTo, out side, out var offset));
-        Assert.AreEqual(PosType.Relative, type);
-        Assert.AreSame(d, relativeTo);
-        Assert.AreEqual(Side.Top, side);
+        ClassicAssert.IsTrue(Pos.Top(v).GetPosType(new List<Design> { d }, out var type, out var val, out relativeTo, out side, out var offset));
+        ClassicAssert.AreEqual(PosType.Relative, type);
+        ClassicAssert.AreSame(d, relativeTo);
+        ClassicAssert.AreEqual(Side.Top, side);
     }
 
     [Test]
     public void TestIsAnchorEnd()
     {
-        Assert.IsFalse(Pos.AnchorEnd().IsAbsolute());
-        Assert.IsFalse(Pos.AnchorEnd().IsPercent());
-        Assert.IsFalse(Pos.AnchorEnd().IsRelative());
-        Assert.IsTrue(Pos.AnchorEnd().IsAnchorEnd(out _));
+        ClassicAssert.IsFalse(Pos.AnchorEnd().IsAbsolute());
+        ClassicAssert.IsFalse(Pos.AnchorEnd().IsPercent());
+        ClassicAssert.IsFalse(Pos.AnchorEnd().IsRelative());
+        ClassicAssert.IsTrue(Pos.AnchorEnd().IsAnchorEnd(out _));
 
-        Assert.IsTrue(Pos.AnchorEnd().IsAnchorEnd(out var margin));
-        Assert.AreEqual(0, margin);
+        ClassicAssert.IsTrue(Pos.AnchorEnd().IsAnchorEnd(out var margin));
+        ClassicAssert.AreEqual(0, margin);
 
-        Assert.IsTrue(Pos.AnchorEnd().GetPosType(new List<Design>(), out var type, out var val, out var design, out var side, out var offset));
-        Assert.AreEqual(PosType.AnchorEnd, type);
-        Assert.AreEqual(0, val);
-        Assert.AreEqual(0, offset);
+        ClassicAssert.IsTrue(Pos.AnchorEnd().GetPosType(new List<Design>(), out var type, out var val, out var design, out var side, out var offset));
+        ClassicAssert.AreEqual(PosType.AnchorEnd, type);
+        ClassicAssert.AreEqual(0, val);
+        ClassicAssert.AreEqual(0, offset);
     }
 
     [Test]
     public void TestIsAnchorEnd_WithMargin()
     {
-        Assert.IsFalse(Pos.AnchorEnd(2).IsAbsolute());
-        Assert.IsFalse(Pos.AnchorEnd(2).IsPercent());
-        Assert.IsFalse(Pos.AnchorEnd(2).IsRelative());
-        Assert.IsTrue(Pos.AnchorEnd(2).IsAnchorEnd(out _));
+        ClassicAssert.IsFalse(Pos.AnchorEnd(2).IsAbsolute());
+        ClassicAssert.IsFalse(Pos.AnchorEnd(2).IsPercent());
+        ClassicAssert.IsFalse(Pos.AnchorEnd(2).IsRelative());
+        ClassicAssert.IsTrue(Pos.AnchorEnd(2).IsAnchorEnd(out _));
 
-        Assert.IsTrue(Pos.AnchorEnd(2).IsAnchorEnd(out var margin));
-        Assert.AreEqual(2, margin);
+        ClassicAssert.IsTrue(Pos.AnchorEnd(2).IsAnchorEnd(out var margin));
+        ClassicAssert.AreEqual(2, margin);
 
-        Assert.IsTrue(Pos.AnchorEnd(2).GetPosType(new List<Design>(), out var type, out var val, out var design, out var side, out var offset));
-        Assert.AreEqual(PosType.AnchorEnd, type);
-        Assert.AreEqual(2, val);
-        Assert.AreEqual(0, offset);
+        ClassicAssert.IsTrue(Pos.AnchorEnd(2).GetPosType(new List<Design>(), out var type, out var val, out var design, out var side, out var offset));
+        ClassicAssert.AreEqual(PosType.AnchorEnd, type);
+        ClassicAssert.AreEqual(2, val);
+        ClassicAssert.AreEqual(0, offset);
     }
 
     [Test]
     public void TestIsAnchorEnd_WithOffset()
     {
-        Assert.IsTrue((Pos.AnchorEnd(1) + 2).GetPosType(new List<Design>(), out var type, out var val, out var design, out var side, out var offset));
-        Assert.AreEqual(PosType.AnchorEnd, type);
-        Assert.AreEqual(1, val);
-        Assert.AreEqual(2, offset);
+        ClassicAssert.IsTrue((Pos.AnchorEnd(1) + 2).GetPosType(new List<Design>(), out var type, out var val, out var design, out var side, out var offset));
+        ClassicAssert.AreEqual(PosType.AnchorEnd, type);
+        ClassicAssert.AreEqual(1, val);
+        ClassicAssert.AreEqual(2, offset);
 
-        Assert.IsTrue((Pos.AnchorEnd(1) - 2).GetPosType(new List<Design>(), out type, out val, out design, out side, out offset));
-        Assert.AreEqual(PosType.AnchorEnd, type);
-        Assert.AreEqual(1, val);
-        Assert.AreEqual(-2, offset);
+        ClassicAssert.IsTrue((Pos.AnchorEnd(1) - 2).GetPosType(new List<Design>(), out type, out val, out design, out side, out offset));
+        ClassicAssert.AreEqual(PosType.AnchorEnd, type);
+        ClassicAssert.AreEqual(1, val);
+        ClassicAssert.AreEqual(-2, offset);
     }
 
     [Test]
@@ -140,30 +140,30 @@ internal class PosTests : Tests
         var d = new Design(new SourceCodeFile(new FileInfo("yarg.cs")), "myView", v);
 
         var p = Pos.Percent(50) + 2;
-        Assert.True(p.GetPosType(new List<Design> { d }, out PosType type, out float value, out var relativeTo, out var side, out int offset), $"Could not figure out PosType for '{p}'");
-        Assert.AreEqual(PosType.Percent, type);
-        Assert.AreEqual(50, value);
-        Assert.AreEqual(2, offset);
+        ClassicAssert.True(p.GetPosType(new List<Design> { d }, out PosType type, out float value, out var relativeTo, out var side, out int offset), $"Could not figure out PosType for '{p}'");
+        ClassicAssert.AreEqual(PosType.Percent, type);
+        ClassicAssert.AreEqual(50, value);
+        ClassicAssert.AreEqual(2, offset);
 
         p = Pos.Percent(50) - 2;
-        Assert.True(p.GetPosType(new List<Design> { d }, out type, out value, out relativeTo, out side, out offset), $"Could not figure out PosType for '{p}'");
-        Assert.AreEqual(PosType.Percent, type);
-        Assert.AreEqual(50, value);
-        Assert.AreEqual(-2, offset);
+        ClassicAssert.True(p.GetPosType(new List<Design> { d }, out type, out value, out relativeTo, out side, out offset), $"Could not figure out PosType for '{p}'");
+        ClassicAssert.AreEqual(PosType.Percent, type);
+        ClassicAssert.AreEqual(50, value);
+        ClassicAssert.AreEqual(-2, offset);
 
         p = Pos.Top(v) + 2;
-        Assert.True(p.GetPosType(new List<Design> { d }, out type, out value, out relativeTo, out side, out offset), $"Could not figure out PosType for '{p}'");
-        Assert.AreEqual(PosType.Relative, type);
-        Assert.AreSame(d, relativeTo);
-        Assert.AreEqual(Side.Top, side);
-        Assert.AreEqual(2, offset);
+        ClassicAssert.True(p.GetPosType(new List<Design> { d }, out type, out value, out relativeTo, out side, out offset), $"Could not figure out PosType for '{p}'");
+        ClassicAssert.AreEqual(PosType.Relative, type);
+        ClassicAssert.AreSame(d, relativeTo);
+        ClassicAssert.AreEqual(Side.Top, side);
+        ClassicAssert.AreEqual(2, offset);
 
         p = Pos.Top(v) - 2;
-        Assert.True(p.GetPosType(new List<Design> { d }, out type, out value, out relativeTo, out side, out offset), $"Could not figure out PosType for '{p}'");
-        Assert.AreEqual(PosType.Relative, type);
-        Assert.AreSame(d, relativeTo);
-        Assert.AreEqual(Side.Top, side);
-        Assert.AreEqual(-2, offset);
+        ClassicAssert.True(p.GetPosType(new List<Design> { d }, out type, out value, out relativeTo, out side, out offset), $"Could not figure out PosType for '{p}'");
+        ClassicAssert.AreEqual(PosType.Relative, type);
+        ClassicAssert.AreSame(d, relativeTo);
+        ClassicAssert.AreEqual(Side.Top, side);
+        ClassicAssert.AreEqual(-2, offset);
     }
 
     [Test]
@@ -171,23 +171,23 @@ internal class PosTests : Tests
     {
         var v = new View();
 
-        Assert.IsNull(v.X, "As of v1.7.0 a new View started getting null for its X, if this assert fails it means that behaviour was reverted and this test can be altered or suppressed");
+        ClassicAssert.IsNull(v.X, "As of v1.7.0 a new View started getting null for its X, if this assert fails it means that behaviour was reverted and this test can be altered or suppressed");
 
-        Assert.IsTrue(v.X.IsAbsolute());
-        Assert.IsTrue(v.X.IsAbsolute(out int n));
-        Assert.AreEqual(0, n);
+        ClassicAssert.IsTrue(v.X.IsAbsolute());
+        ClassicAssert.IsTrue(v.X.IsAbsolute(out int n));
+        ClassicAssert.AreEqual(0, n);
 
-        Assert.IsFalse(v.X.IsPercent());
-        Assert.IsFalse(v.X.IsCombine());
-        Assert.IsFalse(v.X.IsCenter());
+        ClassicAssert.IsFalse(v.X.IsPercent());
+        ClassicAssert.IsFalse(v.X.IsCombine());
+        ClassicAssert.IsFalse(v.X.IsCenter());
 
-        Assert.IsFalse(v.X.IsRelative());
-        Assert.IsFalse(v.X.IsRelative(new List<Design>(), out _, out _));
+        ClassicAssert.IsFalse(v.X.IsRelative());
+        ClassicAssert.IsFalse(v.X.IsRelative(new List<Design>(), out _, out _));
 
-        Assert.IsTrue(v.X.GetPosType(new List<Design>(), out var type, out var val, out _, out _, out _));
+        ClassicAssert.IsTrue(v.X.GetPosType(new List<Design>(), out var type, out var val, out _, out _, out _));
 
-        Assert.AreEqual(PosType.Absolute, type);
-        Assert.AreEqual(0, val);
+        ClassicAssert.AreEqual(PosType.Absolute, type);
+        ClassicAssert.AreEqual(0, val);
     }
 
     [Test]
@@ -197,16 +197,16 @@ internal class PosTests : Tests
         var d = new Design(new SourceCodeFile(new FileInfo("yarg.cs")), "myView", v);
 
         var p = Pos.Percent(50);
-        Assert.AreEqual("Pos.Percent(50f)", p.ToCode(new List<Design> { d }));
+        ClassicAssert.AreEqual("Pos.Percent(50f)", p.ToCode(new List<Design> { d }));
 
         p = Pos.Left(v);
-        Assert.AreEqual("Pos.Left(myView)", p.ToCode(new List<Design> { d }));
+        ClassicAssert.AreEqual("Pos.Left(myView)", p.ToCode(new List<Design> { d }));
         p = Pos.Right(v);
-        Assert.AreEqual("Pos.Right(myView)", p.ToCode(new List<Design> { d }));
+        ClassicAssert.AreEqual("Pos.Right(myView)", p.ToCode(new List<Design> { d }));
         p = Pos.Bottom(v);
-        Assert.AreEqual("Pos.Bottom(myView)", p.ToCode(new List<Design> { d }));
+        ClassicAssert.AreEqual("Pos.Bottom(myView)", p.ToCode(new List<Design> { d }));
         p = Pos.Top(v);
-        Assert.AreEqual("Pos.Top(myView)", p.ToCode(new List<Design> { d }));
+        ClassicAssert.AreEqual("Pos.Top(myView)", p.ToCode(new List<Design> { d }));
     }
 
     [Test]
@@ -216,16 +216,16 @@ internal class PosTests : Tests
         var d = new Design(new SourceCodeFile(new FileInfo("yarg.cs")), "myView", v);
 
         var p = Pos.Percent(50) + 2;
-        Assert.AreEqual("Pos.Percent(50f) + 2", p.ToCode(new List<Design> { d }));
+        ClassicAssert.AreEqual("Pos.Percent(50f) + 2", p.ToCode(new List<Design> { d }));
 
         p = Pos.Percent(50) - 2;
-        Assert.AreEqual("Pos.Percent(50f) - 2", p.ToCode(new List<Design> { d }));
+        ClassicAssert.AreEqual("Pos.Percent(50f) - 2", p.ToCode(new List<Design> { d }));
 
         p = Pos.Right(v) + 2;
-        Assert.AreEqual("Pos.Right(myView) + 2", p.ToCode(new List<Design> { d }));
+        ClassicAssert.AreEqual("Pos.Right(myView) + 2", p.ToCode(new List<Design> { d }));
 
         p = Pos.Right(v) - 2;
-        Assert.AreEqual("Pos.Right(myView) - 2", p.ToCode(new List<Design> { d }));
+        ClassicAssert.AreEqual("Pos.Right(myView) - 2", p.ToCode(new List<Design> { d }));
     }
 
     [TestCase(Side.Left, -2, "X")]
@@ -286,11 +286,11 @@ internal class PosTests : Tests
             btnIn.Y.GetPosType(designBackIn.GetAllDesigns().ToList(), out backInType, out _, out backInRelativeTo, out backInSide, out backInOffset);
         }
 
-        Assert.AreEqual(side, backInSide);
-        Assert.AreEqual(PosType.Relative, backInType);
-        Assert.AreEqual(offset, backInOffset);
-        Assert.IsNotNull(backInRelativeTo);
-        Assert.IsInstanceOf<Label>(backInRelativeTo?.View);
+        ClassicAssert.AreEqual(side, backInSide);
+        ClassicAssert.AreEqual(PosType.Relative, backInType);
+        ClassicAssert.AreEqual(offset, backInOffset);
+        ClassicAssert.IsNotNull(backInRelativeTo);
+        ClassicAssert.IsInstanceOf<Label>(backInRelativeTo?.View);
     }
 
     [Test]
@@ -319,14 +319,14 @@ internal class PosTests : Tests
         var lblIn = designBackIn.View.GetActualSubviews().OfType<Label>().Single();
 
         lblIn.X.GetPosType(designBackIn.GetAllDesigns().ToList(), out var backInType, out var backInValue, out _, out _, out var backInOffset);
-        Assert.AreEqual(0, backInOffset);
-        Assert.AreEqual(PosType.AnchorEnd, backInType);
-        Assert.AreEqual(1, backInValue);
+        ClassicAssert.AreEqual(0, backInOffset);
+        ClassicAssert.AreEqual(PosType.AnchorEnd, backInType);
+        ClassicAssert.AreEqual(1, backInValue);
 
         lblIn.Y.GetPosType(designBackIn.GetAllDesigns().ToList(), out backInType, out backInValue, out _, out _, out backInOffset);
-        Assert.AreEqual(0, backInOffset);
-        Assert.AreEqual(PosType.AnchorEnd, backInType);
-        Assert.AreEqual(4, backInValue);
+        ClassicAssert.AreEqual(0, backInOffset);
+        ClassicAssert.AreEqual(PosType.AnchorEnd, backInType);
+        ClassicAssert.AreEqual(4, backInValue);
     }
 
     [Test]
@@ -355,13 +355,13 @@ internal class PosTests : Tests
         var lblIn = designBackIn.View.GetActualSubviews().OfType<Label>().Single();
 
         lblIn.X.GetPosType(designBackIn.GetAllDesigns().ToList(), out var backInType, out var backInValue, out _, out _, out var backInOffset);
-        Assert.AreEqual(5, backInOffset);
-        Assert.AreEqual(PosType.AnchorEnd, backInType);
-        Assert.AreEqual(1, backInValue);
+        ClassicAssert.AreEqual(5, backInOffset);
+        ClassicAssert.AreEqual(PosType.AnchorEnd, backInType);
+        ClassicAssert.AreEqual(1, backInValue);
 
         lblIn.Y.GetPosType(designBackIn.GetAllDesigns().ToList(), out backInType, out backInValue, out _, out _, out backInOffset);
-        Assert.AreEqual(-3, backInOffset);
-        Assert.AreEqual(PosType.AnchorEnd, backInType);
-        Assert.AreEqual(4, backInValue);
+        ClassicAssert.AreEqual(-3, backInOffset);
+        ClassicAssert.AreEqual(PosType.AnchorEnd, backInType);
+        ClassicAssert.AreEqual(4, backInValue);
     }
 }

--- a/tests/PropertyTests.cs
+++ b/tests/PropertyTests.cs
@@ -26,7 +26,7 @@ internal class PropertyTests : Tests
         var rhs = (CodeSnippetExpression)xProp.GetRhs();
 
         // The code generated for a Property of Type Pos should be the function call
-        Assert.AreEqual(rhs.Value, "Pos.Center()");
+        ClassicAssert.AreEqual(rhs.Value, "Pos.Center()");
     }
 
     [Test]
@@ -40,7 +40,7 @@ internal class PropertyTests : Tests
         var rhs = (CodeSnippetExpression)xProp.GetRhs();
 
         // The code generated for a Property of Type Pos should be the function call
-        Assert.AreEqual(rhs.Value, "Pos.Center()");
+        ClassicAssert.AreEqual(rhs.Value, "Pos.Center()");
     }
 
     [Test]
@@ -52,12 +52,12 @@ internal class PropertyTests : Tests
         colorProp.SetValue(null);
 
         var rhs = (CodeSnippetExpression)colorProp.GetRhs();
-        Assert.AreEqual(rhs.Value, "null");
+        ClassicAssert.AreEqual(rhs.Value, "null");
 
         colorProp.SetValue(Attribute.Make(Color.BrightMagenta, Color.Blue));
 
         rhs = (CodeSnippetExpression)colorProp.GetRhs();
-        Assert.AreEqual(rhs.Value, "Terminal.Gui.Attribute.Make(Color.BrightMagenta,Color.Blue)");
+        ClassicAssert.AreEqual(rhs.Value, "Terminal.Gui.Attribute.Make(Color.BrightMagenta,Color.Blue)");
     }
 
     [Test]
@@ -71,7 +71,7 @@ internal class PropertyTests : Tests
         var rhs = (CodeObjectCreateExpression)pointProp.GetRhs();
 
         // The code generated should be a new PointF
-        Assert.AreEqual(rhs.Parameters.Count, 2);
+        ClassicAssert.AreEqual(rhs.Parameters.Count, 2);
     }
 
     [Test]
@@ -86,11 +86,11 @@ internal class PropertyTests : Tests
 
         prop.SetValue('F');
 
-        Assert.AreEqual(new Rune('F'), lv.LineRune);
+        ClassicAssert.AreEqual(new Rune('F'), lv.LineRune);
 
         var code = ExpressionToCode(prop.GetRhs());
 
-        Assert.AreEqual("'F'", code);
+        ClassicAssert.AreEqual("'F'", code);
     }
 
     [Test]
@@ -103,23 +103,23 @@ internal class PropertyTests : Tests
         v.View.Add(lv);
         lv.IsInitialized = true;
 
-        Assert.AreEqual(Orientation.Horizontal, lv.Orientation);
-        Assert.AreEqual(Application.Driver.HRLine, lv.LineRune);
+        ClassicAssert.AreEqual(Orientation.Horizontal, lv.Orientation);
+        ClassicAssert.AreEqual(Application.Driver.HRLine, lv.LineRune);
         var prop = d.GetDesignableProperty(nameof(LineView.Orientation));
 
-        Assert.IsNotNull(prop);
+        ClassicAssert.IsNotNull(prop);
         prop?.SetValue(Orientation.Vertical);
-        Assert.AreEqual(Application.Driver.VLine, lv.LineRune);
+        ClassicAssert.AreEqual(Application.Driver.VLine, lv.LineRune);
 
         // now try with a dim fill
         lv.Height = Dim.Fill();
         lv.Width = 1;
 
         prop?.SetValue(Orientation.Horizontal);
-        Assert.AreEqual(Orientation.Horizontal, lv.Orientation);
-        Assert.AreEqual(Application.Driver.HRLine, lv.LineRune);
-        Assert.AreEqual(Dim.Fill(), lv.Width);
-        Assert.AreEqual(Dim.Sized(1), lv.Height);
+        ClassicAssert.AreEqual(Orientation.Horizontal, lv.Orientation);
+        ClassicAssert.AreEqual(Application.Driver.HRLine, lv.LineRune);
+        ClassicAssert.AreEqual(Dim.Fill(), lv.Width);
+        ClassicAssert.AreEqual(Dim.Sized(1), lv.Height);
     }
 
     public static string ExpressionToCode(CodeExpression expression)

--- a/tests/RadioGroupTests.cs
+++ b/tests/RadioGroupTests.cs
@@ -12,10 +12,10 @@ class RadioGroupTests : Tests
 
         var rgIn = this.RoundTrip<Window, RadioGroup>((_, _) => { }, out _);
 
-        Assert.AreEqual(2, rgIn.RadioLabels.Length);
+        ClassicAssert.AreEqual(2, rgIn.RadioLabels.Length);
 
-        Assert.AreEqual("Option 1", rgIn.RadioLabels[0].ToString());
-        Assert.AreEqual("Option 2", rgIn.RadioLabels[1].ToString());
+        ClassicAssert.AreEqual("Option 1", rgIn.RadioLabels[0].ToString());
+        ClassicAssert.AreEqual("Option 2", rgIn.RadioLabels[1].ToString());
     }
 
     [Test]
@@ -28,11 +28,11 @@ class RadioGroupTests : Tests
                 r.RadioLabels = new ustring[] { "Fish", "Cat", "Balloon" };
         }, out _);
 
-        Assert.AreEqual(3, rgIn.RadioLabels.Length);
+        ClassicAssert.AreEqual(3, rgIn.RadioLabels.Length);
 
-        Assert.AreEqual("Fish", rgIn.RadioLabels[0].ToString());
-        Assert.AreEqual("Cat", rgIn.RadioLabels[1].ToString());
-        Assert.AreEqual("Balloon", rgIn.RadioLabels[2].ToString());
+        ClassicAssert.AreEqual("Fish", rgIn.RadioLabels[0].ToString());
+        ClassicAssert.AreEqual("Cat", rgIn.RadioLabels[1].ToString());
+        ClassicAssert.AreEqual("Balloon", rgIn.RadioLabels[2].ToString());
     }
 
     [Test]
@@ -44,6 +44,6 @@ class RadioGroupTests : Tests
                 r.RadioLabels = new ustring[] { };
             }, out _);
 
-        Assert.IsEmpty(rgIn.RadioLabels);
+        ClassicAssert.IsEmpty(rgIn.RadioLabels);
     }
 }

--- a/tests/ScrollViewTests.cs
+++ b/tests/ScrollViewTests.cs
@@ -16,9 +16,9 @@ class ScrollViewTests : Tests
                 s.ContentSize = new Size(10, 5),
             out var scrollViewOut);
 
-        Assert.AreNotSame(scrollViewOut, scrollViewIn);
-        Assert.AreEqual(10, scrollViewIn.ContentSize.Width);
-        Assert.AreEqual(5, scrollViewIn.ContentSize.Height);
+        ClassicAssert.AreNotSame(scrollViewOut, scrollViewIn);
+        ClassicAssert.AreEqual(10, scrollViewIn.ContentSize.Width);
+        ClassicAssert.AreEqual(5, scrollViewIn.ContentSize.Height);
     }
 
     [Test]
@@ -32,12 +32,12 @@ class ScrollViewTests : Tests
                 }, out _);
 
         var child = scrollViewIn.GetActualSubviews().Single();
-        Assert.IsInstanceOf<Label>(child);
-        Assert.IsInstanceOf<Design>(child.Data);
+        ClassicAssert.IsInstanceOf<Label>(child);
+        ClassicAssert.IsInstanceOf<Design>(child.Data);
 
         var lblIn = (Design)child.Data;
-        Assert.AreEqual("myLbl", lblIn.FieldName);
-        Assert.AreEqual("blarggg", lblIn.View.Text.ToString());
+        ClassicAssert.AreEqual("myLbl", lblIn.FieldName);
+        ClassicAssert.AreEqual("blarggg", lblIn.View.Text.ToString());
     }
 
     [Test]
@@ -60,7 +60,7 @@ class ScrollViewTests : Tests
                 }, out _);
 
         // The ScrollView should contain the Button
-        Assert.Contains(buttonOut, scrollOut.GetActualSubviews().ToArray());
+        ClassicAssert.Contains(buttonOut, scrollOut.GetActualSubviews().ToArray());
 
         // The TabView read back in should contain the ScrollView
         var scrollIn = tabIn.Tabs.First()
@@ -69,7 +69,7 @@ class ScrollViewTests : Tests
                 .Single();
 
         var butttonIn = scrollIn.GetActualSubviews().Single();
-        Assert.IsInstanceOf<Button>(butttonIn);
-        Assert.AreNotSame(buttonOut, butttonIn);
+        ClassicAssert.IsInstanceOf<Button>(butttonIn);
+        ClassicAssert.AreNotSame(buttonOut, butttonIn);
     }
 }

--- a/tests/StatusBarTests.cs
+++ b/tests/StatusBarTests.cs
@@ -13,13 +13,13 @@ namespace UnitTests
 
             var statusBarIn = RoundTrip<Toplevel, StatusBar>((d, v) =>
             {
-                Assert.AreEqual(1, v.Items.Length, $"Expected {nameof(ViewFactory)} to create a placeholder status item in new StatusBars it creates");
+                ClassicAssert.AreEqual(1, v.Items.Length, $"Expected {nameof(ViewFactory)} to create a placeholder status item in new StatusBars it creates");
                 shortcutBefore = v.Items[0].Shortcut;
 
             }, out _);
 
-            Assert.AreEqual(1, statusBarIn.Items.Length, $"Expected reloading StatusBar to create the same number of StatusItems");
-            Assert.AreEqual(shortcutBefore, statusBarIn.Items[0].Shortcut);
+            ClassicAssert.AreEqual(1, statusBarIn.Items.Length, $"Expected reloading StatusBar to create the same number of StatusItems");
+            ClassicAssert.AreEqual(shortcutBefore, statusBarIn.Items[0].Shortcut);
         }
     }
 }

--- a/tests/StringExtensionTests.cs
+++ b/tests/StringExtensionTests.cs
@@ -14,7 +14,7 @@ internal class StringExtensionTests
     [TestCase("Fish1", "Fish1", new[] { "fish1"})] // default behavior is case sensitive
     public void TestMakeUnique_DefaultComparer(string stringIn, string expectedOut, string[] whenCollection)
     {
-        Assert.AreEqual(expectedOut, stringIn.MakeUnique(whenCollection));
+        ClassicAssert.AreEqual(expectedOut, stringIn.MakeUnique(whenCollection));
     }
 
     [TestCase("bob", "bob", new[] { "fish" })]
@@ -23,7 +23,7 @@ internal class StringExtensionTests
     [TestCase("fish2", "fish3", new[] { "fiSH1", "fiSH2" })]
     public void TestMakeUnique_IgnoreCaps(string stringIn, string expectedOut, string[] whenCollection)
     {
-        Assert.AreEqual(expectedOut, stringIn.MakeUnique(whenCollection,System.StringComparer.InvariantCultureIgnoreCase));
+        ClassicAssert.AreEqual(expectedOut, stringIn.MakeUnique(whenCollection,System.StringComparer.InvariantCultureIgnoreCase));
     }
 
     [TestCase("a",4," a  ")]
@@ -32,6 +32,6 @@ internal class StringExtensionTests
     [TestCase("sooooLooong", 2, "sooooLooong")]
     public void TestPadBoth(string input, int length, string expectedOutput)
     {
-        Assert.AreEqual(expectedOutput, input.PadBoth(length));
+        ClassicAssert.AreEqual(expectedOutput, input.PadBoth(length));
     }
 }

--- a/tests/TabViewTests.cs
+++ b/tests/TabViewTests.cs
@@ -17,13 +17,13 @@ class TabViewTests : Tests
     {
         TabView tabIn = this.RoundTrip<Dialog, TabView>(
             (d, t) =>
-            Assert.IsNotEmpty(t.Tabs, "Expected default TabView created by ViewFactory to have some placeholder Tabs"),
+            ClassicAssert.IsNotEmpty(t.Tabs, "Expected default TabView created by ViewFactory to have some placeholder Tabs"),
             out TabView tabOut);
 
-        Assert.AreEqual(2, tabIn.Tabs.Count());
+        ClassicAssert.AreEqual(2, tabIn.Tabs.Count());
 
-        Assert.AreEqual("Tab1", tabIn.Tabs.ElementAt(0).Text);
-        Assert.AreEqual("Tab2", tabIn.Tabs.ElementAt(1).Text);
+        ClassicAssert.AreEqual("Tab1", tabIn.Tabs.ElementAt(0).Text);
+        ClassicAssert.AreEqual("Tab2", tabIn.Tabs.ElementAt(1).Text);
     }
 
     /// <summary>
@@ -51,37 +51,37 @@ class TabViewTests : Tests
         var d = this.GetTabView();
         var tv = (TabView)d.View;
 
-        Assert.AreEqual("Tab1", tv.Tabs.ElementAt(0).Text);
-        Assert.AreEqual("Tab2", tv.Tabs.ElementAt(1).Text);
+        ClassicAssert.AreEqual("Tab1", tv.Tabs.ElementAt(0).Text);
+        ClassicAssert.AreEqual("Tab2", tv.Tabs.ElementAt(1).Text);
 
         // Select Tab1
         tv.SelectedTab = tv.Tabs.First();
 
         // try to move tab 1 left
         var cmd = new MoveTabOperation(d, tv.SelectedTab, -1);
-        Assert.IsFalse(cmd.Do(), "Expected not to be able to move tab left because selected is the first");
+        ClassicAssert.IsFalse(cmd.Do(), "Expected not to be able to move tab left because selected is the first");
 
         // Select Tab2
         tv.SelectedTab = tv.Tabs.Last();
 
-        Assert.AreEqual(tv.SelectedTab.Text, "Tab2", "Tab2 should be selected before operation is applied");
+        ClassicAssert.AreEqual(tv.SelectedTab.Text, "Tab2", "Tab2 should be selected before operation is applied");
 
         // try to move tab 2 left
         cmd = new MoveTabOperation(d, tv.SelectedTab, -1);
-        Assert.IsFalse(cmd.IsImpossible);
-        Assert.IsTrue(cmd.Do());
+        ClassicAssert.IsFalse(cmd.IsImpossible);
+        ClassicAssert.IsTrue(cmd.Do());
 
-        Assert.AreEqual(tv.SelectedTab.Text, "Tab2", "Tab2 should still be selected after operation is applied");
+        ClassicAssert.AreEqual(tv.SelectedTab.Text, "Tab2", "Tab2 should still be selected after operation is applied");
 
         // tabs should now be in reverse order
-        Assert.AreEqual("Tab2", tv.Tabs.ElementAt(0).Text);
-        Assert.AreEqual("Tab1", tv.Tabs.ElementAt(1).Text);
+        ClassicAssert.AreEqual("Tab2", tv.Tabs.ElementAt(0).Text);
+        ClassicAssert.AreEqual("Tab1", tv.Tabs.ElementAt(1).Text);
 
         cmd.Undo();
 
         // undoing command should revert to original tab order
-        Assert.AreEqual("Tab1", tv.Tabs.ElementAt(0).Text);
-        Assert.AreEqual("Tab2", tv.Tabs.ElementAt(1).Text);
+        ClassicAssert.AreEqual("Tab1", tv.Tabs.ElementAt(0).Text);
+        ClassicAssert.AreEqual("Tab2", tv.Tabs.ElementAt(1).Text);
     }
 
     [Test]
@@ -90,38 +90,38 @@ class TabViewTests : Tests
         var d = this.GetTabView();
         var tv = (TabView)d.View;
 
-        Assert.AreEqual(2, tv.Tabs.Count);
-        Assert.AreEqual("Tab1", tv.Tabs.ElementAt(0).Text);
-        Assert.AreEqual("Tab2", tv.Tabs.ElementAt(1).Text);
+        ClassicAssert.AreEqual(2, tv.Tabs.Count);
+        ClassicAssert.AreEqual("Tab1", tv.Tabs.ElementAt(0).Text);
+        ClassicAssert.AreEqual("Tab2", tv.Tabs.ElementAt(1).Text);
 
         // Select Tab1
         tv.SelectedTab = tv.Tabs.First();
 
         // try to remove the first tab
-        Assert.IsTrue(OperationManager.Instance.Do(new RemoveTabOperation(d, tv.SelectedTab)));
+        ClassicAssert.IsTrue(OperationManager.Instance.Do(new RemoveTabOperation(d, tv.SelectedTab)));
 
-        Assert.AreEqual(1, tv.Tabs.Count);
-        Assert.AreEqual("Tab2", tv.Tabs.ElementAt(0).Text);
+        ClassicAssert.AreEqual(1, tv.Tabs.Count);
+        ClassicAssert.AreEqual("Tab2", tv.Tabs.ElementAt(0).Text);
 
         // remove the last tab (tab2)
-        Assert.IsTrue(OperationManager.Instance.Do(new RemoveTabOperation(d, tv.SelectedTab)));
-        Assert.IsEmpty(tv.Tabs);
+        ClassicAssert.IsTrue(OperationManager.Instance.Do(new RemoveTabOperation(d, tv.SelectedTab)));
+        ClassicAssert.IsEmpty(tv.Tabs);
 
         OperationManager.Instance.Undo();
 
-        Assert.AreEqual(1, tv.Tabs.Count);
-        Assert.AreEqual("Tab2", tv.Tabs.ElementAt(0).Text);
+        ClassicAssert.AreEqual(1, tv.Tabs.Count);
+        ClassicAssert.AreEqual("Tab2", tv.Tabs.ElementAt(0).Text);
 
         OperationManager.Instance.Redo();
-        Assert.IsEmpty(tv.Tabs);
+        ClassicAssert.IsEmpty(tv.Tabs);
 
         // undo removing both
         OperationManager.Instance.Undo();
         OperationManager.Instance.Undo();
 
-        Assert.AreEqual(2, tv.Tabs.Count);
-        Assert.AreEqual("Tab1", tv.Tabs.ElementAt(0).Text.ToString());
-        Assert.AreEqual("Tab2", tv.Tabs.ElementAt(1).Text.ToString());
+        ClassicAssert.AreEqual(2, tv.Tabs.Count);
+        ClassicAssert.AreEqual("Tab1", tv.Tabs.ElementAt(0).Text.ToString());
+        ClassicAssert.AreEqual("Tab2", tv.Tabs.ElementAt(1).Text.ToString());
     }
 
     [Test]
@@ -150,10 +150,10 @@ class TabViewTests : Tests
 
         var tabIn = designBackIn.View.GetActualSubviews().OfType<TabView>().Single();
 
-        Assert.AreEqual(2, tabIn.Tabs.Count());
+        ClassicAssert.AreEqual(2, tabIn.Tabs.Count());
 
-        Assert.AreEqual("MyTab", tabIn.Tabs.ElementAt(0).Text.ToString());
-        Assert.AreEqual("MyTab", tabIn.Tabs.ElementAt(1).Text.ToString());
+        ClassicAssert.AreEqual("MyTab", tabIn.Tabs.ElementAt(0).Text.ToString());
+        ClassicAssert.AreEqual("MyTab", tabIn.Tabs.ElementAt(1).Text.ToString());
     }
 
     [Test]
@@ -172,7 +172,7 @@ class TabViewTests : Tests
         var label = factory.Create(typeof(Label));
 
         OperationManager.Instance.Do(new AddViewOperation(label, (Design)tvOut.Data, "myLabel"));
-        Assert.Contains(label, tvOut.SelectedTab.View.Subviews.ToArray(), "Expected currently selected tab to have the new label but it did not");
+        ClassicAssert.Contains(label, tvOut.SelectedTab.View.Subviews.ToArray(), "Expected currently selected tab to have the new label but it did not");
 
         viewToCode.GenerateDesignerCs(designOut, typeof(Dialog));
 
@@ -182,7 +182,7 @@ class TabViewTests : Tests
         var tabIn = designBackIn.View.GetActualSubviews().OfType<TabView>().Single();
         var tabInLabel = tabIn.SelectedTab.View.Subviews.Single();
 
-        Assert.AreEqual(label.Text, tabInLabel.Text);
+        ClassicAssert.AreEqual(label.Text, tabInLabel.Text);
     }
 
     [Test]
@@ -203,11 +203,11 @@ class TabViewTests : Tests
 
         var tvDesign = new Design(source, "tv", tv);
 
-        Assert.Contains(tvDesign, tvDesign.GetAllDesigns().ToArray());
-        Assert.Contains(lbl1, tvDesign.GetAllDesigns().ToArray());
-        Assert.Contains(lbl2, tvDesign.GetAllDesigns().ToArray());
+        ClassicAssert.Contains(tvDesign, tvDesign.GetAllDesigns().ToArray());
+        ClassicAssert.Contains(lbl1, tvDesign.GetAllDesigns().ToArray());
+        ClassicAssert.Contains(lbl2, tvDesign.GetAllDesigns().ToArray());
 
-        Assert.AreEqual(3, tvDesign.GetAllDesigns().Count(), $"Expected only 3 Designs but they were {string.Join(",", tvDesign.GetAllDesigns())}");
+        ClassicAssert.AreEqual(3, tvDesign.GetAllDesigns().Count(), $"Expected only 3 Designs but they were {string.Join(",", tvDesign.GetAllDesigns())}");
     }
 
     [Test]
@@ -215,12 +215,12 @@ class TabViewTests : Tests
     {
         var inst = new TabView();
 
-        Assert.IsTrue(inst.Style.ShowBorder);
-        Assert.False(inst.IsBorderlessContainerView());
+        ClassicAssert.IsTrue(inst.Style.ShowBorder);
+        ClassicAssert.False(inst.IsBorderlessContainerView());
 
         inst.Style.ShowBorder = false;
 
-        Assert.True(inst.IsBorderlessContainerView());
+        ClassicAssert.True(inst.IsBorderlessContainerView());
     }
 
     [Test]
@@ -228,11 +228,11 @@ class TabViewTests : Tests
     {
         var inst = new TabView();
 
-        Assert.IsFalse(inst.Style.TabsOnBottom);
-        Assert.False(inst.IsBorderlessContainerView());
+        ClassicAssert.IsFalse(inst.Style.TabsOnBottom);
+        ClassicAssert.False(inst.IsBorderlessContainerView());
 
         inst.Style.TabsOnBottom = true;
 
-        Assert.True(inst.IsBorderlessContainerView());
+        ClassicAssert.True(inst.IsBorderlessContainerView());
     }
 }

--- a/tests/TableViewTests.cs
+++ b/tests/TableViewTests.cs
@@ -13,13 +13,13 @@ internal class TableViewTests : Tests
     public void TestRoundTrip_PreserveColumns()
     {
         TableView tableIn = this.RoundTrip<Window, TableView>(
-            (d, v) => Assert.IsNotEmpty(v.Table.Columns, "Default ViewFactory should create some columns for new TableViews"),
+            (d, v) => ClassicAssert.IsNotEmpty(v.Table.Columns, "Default ViewFactory should create some columns for new TableViews"),
             out TableView tableOut);
 
-        Assert.IsNotNull(tableIn.Table);
+        ClassicAssert.IsNotNull(tableIn.Table);
 
-        Assert.AreEqual(tableOut.Table.Columns.Count, tableIn.Table.Columns.Count);
-        Assert.AreEqual(tableOut.Table.Rows.Count, tableIn.Table.Rows.Count);
+        ClassicAssert.AreEqual(tableOut.Table.Columns.Count, tableIn.Table.Columns.Count);
+        ClassicAssert.AreEqual(tableOut.Table.Rows.Count, tableIn.Table.Rows.Count);
     }
 
     [Test]
@@ -40,7 +40,7 @@ internal class TableViewTests : Tests
         var designBackIn = ((Design)tableIn.Data).GetRootDesign();
         var tables = designBackIn.View.GetActualSubviews().OfType<TableView>().ToArray();
 
-        Assert.AreEqual(2, tables.Length);
+        ClassicAssert.AreEqual(2, tables.Length);
 
         Assert.That(
             tables[0].Table.Columns.Cast<DataColumn>().Select(c => c.ColumnName),

--- a/tests/Tests.cs
+++ b/tests/Tests.cs
@@ -148,6 +148,6 @@ internal class Tests
     {
         var str = "cat";
         object obj = str.CastToReflected(typeof(object));
-        Assert.IsInstanceOf<object>(obj);
+        ClassicAssert.IsInstanceOf<object>(obj);
     }
 }

--- a/tests/TextValidateFieldTests.cs
+++ b/tests/TextValidateFieldTests.cs
@@ -22,7 +22,7 @@ class TextValidateFieldTests : Tests
         var factory = new ViewFactory();
         var tvfOut = (TextValidateField)factory.Create(typeof(TextValidateField));
 
-        Assert.IsNotNull(tvfOut.Provider);
+        ClassicAssert.IsNotNull(tvfOut.Provider);
 
         OperationManager.Instance.Do(new AddViewOperation(tvfOut, designOut, "myfield"));
 
@@ -33,6 +33,6 @@ class TextValidateFieldTests : Tests
 
         var tvfIn = designBackIn.View.GetActualSubviews().OfType<TextValidateField>().Single();
 
-        Assert.IsNotNull(tvfIn.Provider);
+        ClassicAssert.IsNotNull(tvfIn.Provider);
     }
 }

--- a/tests/TextViewTests.cs
+++ b/tests/TextViewTests.cs
@@ -24,6 +24,6 @@ internal class TextViewTests : Tests
 
         op.Do();
 
-        Assert.IsTrue(ustring.IsNullOrEmpty(tv.Text));
+        ClassicAssert.IsTrue(ustring.IsNullOrEmpty(tv.Text));
     }
 }

--- a/tests/ToCode/CodeDomArgsTests.cs
+++ b/tests/ToCode/CodeDomArgsTests.cs
@@ -21,15 +21,15 @@ internal class CodeDomArgsTests
     [TestCaseSource("cases")]
     public void Test_MakeValidFieldName(string? input, string expectedOutput)
     {
-        Assert.AreEqual(expectedOutput, CodeDomArgs.MakeValidFieldName(input));
+        ClassicAssert.AreEqual(expectedOutput, CodeDomArgs.MakeValidFieldName(input));
 
         // when public we should start with an upper case letter
-        Assert.IsTrue(char.IsUpper(CodeDomArgs.MakeValidFieldName(name: input, isPublic: true)[0]));
+        ClassicAssert.IsTrue(char.IsUpper(CodeDomArgs.MakeValidFieldName(name: input, isPublic: true)[0]));
 
         // when private we should start with an upper case letter
-        Assert.IsFalse(char.IsUpper(CodeDomArgs.MakeValidFieldName(name: input, isPublic: false)[0]));
+        ClassicAssert.IsFalse(char.IsUpper(CodeDomArgs.MakeValidFieldName(name: input, isPublic: false)[0]));
 
-        Assert.AreEqual(
+        ClassicAssert.AreEqual(
             CodeDomArgs.MakeValidFieldName(input, true).Substring(1),
             CodeDomArgs.MakeValidFieldName(input, false).Substring(1),
             "Expected public/private to only differ on first letter caps");
@@ -39,7 +39,7 @@ internal class CodeDomArgsTests
     public void Test_GetUniqueFieldName(string? input, string expectOutput)
     {
         var args = new CodeDomArgs(new System.CodeDom.CodeTypeDeclaration(), new System.CodeDom.CodeMemberMethod());
-        Assert.AreEqual(expectOutput, args.GetUniqueFieldName(input), "Expected GetUniqueFieldName to sanitize input in the same way as MakeValidFieldName (see Test_MakeValidFieldName tests)");
+        ClassicAssert.AreEqual(expectOutput, args.GetUniqueFieldName(input), "Expected GetUniqueFieldName to sanitize input in the same way as MakeValidFieldName (see Test_MakeValidFieldName tests)");
     }
 
     [TestCase("bob", "bob", "bob2")]
@@ -48,7 +48,7 @@ internal class CodeDomArgsTests
     {
         var args = new CodeDomArgs(new System.CodeDom.CodeTypeDeclaration(), new System.CodeDom.CodeMemberMethod());
         args.FieldNamesUsed.Add(firstAdd);
-        Assert.AreEqual(expectOutput,args.GetUniqueFieldName(thenInput));
+        ClassicAssert.AreEqual(expectOutput,args.GetUniqueFieldName(thenInput));
     }
 
     [TestCase("if", "_if")]
@@ -59,6 +59,6 @@ internal class CodeDomArgsTests
     [TestCase("else", "_else")]
     public void Test_MakeValidFieldName_ShouldPrependUnderscoreToReservedKeywords(string input, string expectedOutput)
     {
-        Assert.AreEqual(expectedOutput, CodeDomArgs.MakeValidFieldName(input));
+        ClassicAssert.AreEqual(expectedOutput, CodeDomArgs.MakeValidFieldName(input));
     }
 }

--- a/tests/UnitTests.csproj
+++ b/tests/UnitTests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit" Version="4.0.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="YamlDotNet" Version="13.3.1" />
 	  <PackageReference Include="ReportGenerator" Version="5.1.24" />

--- a/tests/UnitTests.csproj
+++ b/tests/UnitTests.csproj
@@ -21,6 +21,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\src\TerminalGuiDesigner.csproj" />
+		<Using Include="NUnit.Framework"/>
+		<Using Include="NUnit.Framework.Legacy"/>
   </ItemGroup>
 
 </Project>

--- a/tests/ViewExtensionsTests.cs
+++ b/tests/ViewExtensionsTests.cs
@@ -43,15 +43,15 @@ internal class ViewExtensionsTests : Tests
         // click didn't land in anything
         if (hit)
         {
-            Assert.AreSame(v, result);
+            ClassicAssert.AreSame(v, result);
         }
         else
         {
-            Assert.IsNull(result);
+            ClassicAssert.IsNull(result);
         }
 
-        Assert.AreEqual(lowerRight, isLowerRight);
-        Assert.AreEqual(border, isBorder);
+        ClassicAssert.AreEqual(lowerRight, isLowerRight);
+        ClassicAssert.AreEqual(border, isBorder);
     }
 
     [TestCase(typeof(Label), false)]
@@ -64,7 +64,7 @@ internal class ViewExtensionsTests : Tests
         var inst = (View?)Activator.CreateInstance(viewType)
             ?? throw new Exception("CreateInstance returned null!");
 
-        Assert.AreEqual(expectIsContainerView, inst.IsContainerView());
+        ClassicAssert.AreEqual(expectIsContainerView, inst.IsContainerView());
     }
 
     [TestCase(typeof(Label), false)]
@@ -77,7 +77,7 @@ internal class ViewExtensionsTests : Tests
         var inst = (View?)Activator.CreateInstance(viewType)
             ?? throw new Exception("CreateInstance returned null!");
 
-        Assert.AreEqual(expectResult, inst.IsBorderlessContainerView());
+        ClassicAssert.AreEqual(expectResult, inst.IsBorderlessContainerView());
     }
 
     [Test]
@@ -94,13 +94,13 @@ internal class ViewExtensionsTests : Tests
         Application.Begin(w);
         w.LayoutSubviews();
 
-        Assert.AreSame(w, w.HitTest(new MouseEvent { X = 0, Y = 0 }, out var isBorder, out _),
+        ClassicAssert.AreSame(w, w.HitTest(new MouseEvent { X = 0, Y = 0 }, out var isBorder, out _),
             "Expected 0,0 to be the window border (its client area should start at 1,1)");
-        Assert.IsTrue(isBorder);
+        ClassicAssert.IsTrue(isBorder);
 
         // 1,1
-        Assert.AreSame(f, w.HitTest(new MouseEvent { X = 1, Y = 1 }, out isBorder, out _),
+        ClassicAssert.AreSame(f, w.HitTest(new MouseEvent { X = 1, Y = 1 }, out isBorder, out _),
             "Expected 1,1 to be the Frame border (its client area should start at 1,1)");
-        Assert.IsTrue(isBorder);
+        ClassicAssert.IsTrue(isBorder);
     }
 }

--- a/tests/VisiblePropertyTests.cs
+++ b/tests/VisiblePropertyTests.cs
@@ -25,15 +25,15 @@ namespace UnitTests
                     );
                 
                 // Should start off visible
-                Assert.AreEqual(true, prop.GetValue());
-                Assert.True(v.Visible);
+                ClassicAssert.AreEqual(true, prop.GetValue());
+                ClassicAssert.True(v.Visible);
 
                 prop.SetValue(false);
 
                 // Prop should know it is not visible
-                Assert.AreEqual(false, prop.GetValue());
+                ClassicAssert.AreEqual(false, prop.GetValue());
                 // But View in editor should remain visible so that it can be clicked on etc
-                Assert.True(v.Visible);
+                ClassicAssert.True(v.Visible);
 
             },out _);
 
@@ -41,8 +41,8 @@ namespace UnitTests
             var d = (Design)result.Data;
             var prop = d.GetDesignableProperties().Single(p => p.PropertyInfo.Name.Equals(nameof(View.Visible)));
 
-            Assert.AreEqual(false, prop.GetValue());
-            Assert.True(result.Visible);
+            ClassicAssert.AreEqual(false, prop.GetValue());
+            ClassicAssert.True(result.Visible);
         }
     }
 }


### PR DESCRIPTION
This includes the changes necessary to make the unit tests compile against NUnit 4.0.

I converted one set of tests to the Constraint style, as an example.

The rest I simply switched to the ClassicAssert class, which is the new location of all of the old assert methods.

No functional changes were made to any tests.

This supersedes #252 opened by Dependabot.\
This also includes the changes from #255, which I opened a little while ago (this branch is branched from that commit).