### PR TITLE
TreeView<T> support

### DIFF
--- a/src/Design.cs
+++ b/src/Design.cs
@@ -806,7 +806,9 @@ public class Design
         
         if (isGenericType && viewType.GetGenericTypeDefinition() == typeof(TreeView<>))
         {
-            yield return this.CreateTreeObjectsProperty(viewType);
+            var prop = this.CreateTreeObjectsProperty(viewType);
+            if(((ITreeObjectsProperty)prop).IsSupported())
+                yield return prop;
         }
 
         if (this.View is TableView tv)

--- a/src/Design.cs
+++ b/src/Design.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Xml.Linq;
 using NLog;
 using Terminal.Gui;
@@ -793,7 +794,7 @@ public class Design
             yield return this.CreateProperty(nameof(FrameView.Title));
         }
 
-        if (this.View is TreeView tree)
+        if (this.View is ITreeView tree)
         {
             yield return this.CreateSubProperty(nameof(TreeStyle.CollapseableSymbol), nameof(TreeView<ITreeNode>.Style), tree.Style);
             yield return this.CreateSubProperty(nameof(TreeStyle.ColorExpandSymbol), nameof(TreeView<ITreeNode>.Style), tree.Style);
@@ -801,6 +802,11 @@ public class Design
             yield return this.CreateSubProperty(nameof(TreeStyle.InvertExpandSymbolColors), nameof(TreeView<ITreeNode>.Style), tree.Style);
             yield return this.CreateSubProperty(nameof(TreeStyle.LeaveLastRow), nameof(TreeView<ITreeNode>.Style), tree.Style);
             yield return this.CreateSubProperty(nameof(TreeStyle.ShowBranchLines), nameof(TreeView<ITreeNode>.Style), tree.Style);
+        }
+        
+        if (isGenericType && viewType.GetGenericTypeDefinition() == typeof(TreeView<>))
+        {
+            yield return this.CreateTreeObjectsProperty(viewType);
         }
 
         if (this.View is TableView tv)
@@ -830,6 +836,23 @@ public class Design
             yield return this.CreateProperty(nameof(RadioGroup.RadioLabels));
             yield return this.CreateProperty(nameof(RadioGroup.DisplayMode));
         }
+    }
+
+    private Property CreateTreeObjectsProperty(Type viewType)
+    {
+        if(viewType.GetGenericTypeDefinition() != typeof(TreeView<>))
+        {
+            throw new ArgumentException("Method should only be called for TreeView<T>");
+        }
+
+        var tType = viewType.GetGenericArguments()[0];
+        var propertyType = typeof(TreeObjectsProperty<>).MakeGenericType(tType);
+
+        var instance =
+            Activator.CreateInstance(propertyType, new object?[] { this })
+            ?? throw new Exception($"Failed to construct {propertyType}");
+
+        return (Property)instance;
     }
 
     private bool ShowTextProperty()

--- a/src/Design.cs
+++ b/src/Design.cs
@@ -48,7 +48,6 @@ public class Design
         typeof(TableView),
         typeof(TabView),
         typeof(TreeView),
-        typeof(TreeView<>),
         typeof(Dialog),
     };
 

--- a/src/DesignState.cs
+++ b/src/DesignState.cs
@@ -22,7 +22,7 @@ public class DesignState
     {
         this.Design = design;
         this.OriginalScheme = this.Design.View.GetExplicitColorScheme();
-        this.Design.View.DrawContent += this.DrawContent;
+        this.Design.View.DrawContentComplete += this.DrawContentComplete;
         this.Design.View.Enter += this.Enter;
     }
 
@@ -49,7 +49,7 @@ public class DesignState
         }
     }
 
-    private void DrawContent(object? sender, DrawEventArgs r)
+    private void DrawContentComplete(object? sender, DrawEventArgs r)
     {
         if (this.Design.View.IsBorderlessContainerView() && Editor.ShowBorders)
         {

--- a/src/FromCode/CodeToView.cs
+++ b/src/FromCode/CodeToView.cs
@@ -159,6 +159,8 @@ public class CodeToView
             MetadataReference.CreateFromFile(coreDir.FullName + Path.DirectorySeparatorChar + "mscorlib.dll"),
             MetadataReference.CreateFromFile(coreDir.FullName + Path.DirectorySeparatorChar + "System.Runtime.dll"),
             MetadataReference.CreateFromFile(coreDir.FullName + Path.DirectorySeparatorChar + "System.Collections.dll"),
+            MetadataReference.CreateFromFile(coreDir.FullName + Path.DirectorySeparatorChar + "System.Data.Common.dll")
+            ,
         };
 
         var options = new CSharpCompilationOptions(

--- a/src/FromCode/CodeToView.cs
+++ b/src/FromCode/CodeToView.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Emit;
 using NLog;
 using Terminal.Gui;
 using TerminalGuiDesigner.ToCode;
+using static Terminal.Gui.SpinnerStyle;
 
 namespace TerminalGuiDesigner.FromCode;
 
@@ -151,7 +152,8 @@ public class CodeToView
         var references = new List<MetadataReference>()
         {
             MetadataReference.CreateFromFile(typeof(View).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(System.Data.DataTable).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.IO.FileSystemInfo).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Linq.Enumerable).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(MarshalByValueComponent).Assembly.Location),
             MetadataReference.CreateFromFile(coreDir.FullName + Path.DirectorySeparatorChar + "mscorlib.dll"),

--- a/src/Operations/AddViewOperation.cs
+++ b/src/Operations/AddViewOperation.cs
@@ -82,7 +82,7 @@ public class AddViewOperation : Operation
             {
                 if (selected.IsGenericType)
                 {
-                    var allowedTTypes = ViewFactory.GetSupportedTTypesForGenericViewOfType(selected).ToArray();
+                    var allowedTTypes = TTypes.GetSupportedTTypesForGenericViewOfType(selected).ToArray();
 
                     if(Modals.Get("Enter a Type for <T>", "Choose", true, allowedTTypes, this.TypeNameDelegate, false, null, out var selectedTType) && selectedTType != null)
                     {

--- a/src/TTypes.cs
+++ b/src/TTypes.cs
@@ -1,0 +1,57 @@
+﻿using System.CodeDom;
+using Terminal.Gui;
+using TerminalGuiDesigner.ToCode;
+
+namespace TerminalGuiDesigner
+{
+    /// <summary>
+    /// Provides knowledge about how to handle different T types for generic
+    /// views e.g. <see cref="Slider{T}"/>, <see cref="TreeView{T}"/>
+    /// </summary>
+    public static class TTypes
+    {
+        /// <summary>
+        /// Returns <see cref="CodeObjectCreateExpression"/> or <see cref="CodePrimitiveExpression"/>
+        /// or similar that represents <paramref name="value"/>.
+        /// </summary>
+        /// <param name="args"></param>
+        /// <param name="design"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static CodeExpression ToCode(CodeDomArgs args, Design design, object? value)
+        {
+            if(value == null || value is string || value.GetType().IsValueType)
+            {
+                return value.ToCodePrimitiveExpression();
+            }
+
+            if(value is FileSystemInfo fsi)
+            {
+                return new CodeObjectCreateExpression(value.GetType(), fsi.ToString().ToCodePrimitiveExpression());
+            }
+
+            throw new NotSupportedException("Value Type ToCode not known" + value.GetType());
+        }
+
+        /// <summary>
+        /// Returns all Types which can be used with generic view of the given <paramref name="viewType"/>.
+        /// </summary>
+        /// <param name="viewType">A generic view type e.g. <see langword="typeof"/>(Slider&lt;&gt;)</param>
+        /// <returns></returns>
+        public static IEnumerable<Type> GetSupportedTTypesForGenericViewOfType(Type viewType)
+        {
+            if (viewType == typeof(Slider<>))
+            {
+                return new[] { typeof(int), typeof(string), typeof(float), typeof(double), typeof(bool) };
+            }
+
+            if (viewType == typeof(TreeView<>))
+            {
+                return new[] { typeof(object), typeof(FileSystemInfo) };
+            }
+
+            throw new NotSupportedException($"Generic View {viewType} is not yet supported");
+        }
+
+    }
+}

--- a/src/TerminalGuiDesigner.cd
+++ b/src/TerminalGuiDesigner.cd
@@ -24,7 +24,7 @@
   <Class Name="TerminalGuiDesigner.Design">
     <Position X="3.75" Y="0.5" Width="2.25" />
     <TypeIdentifier>
-      <HashCode>AhABQBACACKBADAHCAAAAEIQAECJhAAgARAABAAAgAg=</HashCode>
+      <HashCode>AxABQBACAiKBADAnCAAAAEIQAECJhAAgARAABAAAgAg=</HashCode>
       <FileName>Design.cs</FileName>
     </TypeIdentifier>
     <ShowAsAssociation>
@@ -39,7 +39,7 @@
   <Class Name="TerminalGuiDesigner.Operations.AddViewOperation" Collapsed="true" BaseTypeListCollapsed="true">
     <Position X="10.75" Y="3.5" Width="2" />
     <TypeIdentifier>
-      <HashCode>AAAAAAAAAAAABAAAAAAAAIhBABAAAAAAAAAAAAACAAA=</HashCode>
+      <HashCode>AAAAAAAAAAAABAAAAAAAAIhBABABAAAAAAAAAAACAAA=</HashCode>
       <FileName>Operations\AddViewOperation.cs</FileName>
     </TypeIdentifier>
   </Class>
@@ -84,14 +84,14 @@
   <Class Name="TerminalGuiDesigner.UI.Editor">
     <Position X="0.5" Y="0.5" Width="1.75" />
     <TypeIdentifier>
-      <HashCode>IQRiB4gQACICNCQgCABAAAIBigMAQAgBEAFAIQAACAI=</HashCode>
+      <HashCode>IQRiB4gQACICJCQgKABAAAIBigMAQAgBAAEAIQAACAo=</HashCode>
       <FileName>UI\Editor.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="TerminalGuiDesigner.ToCode.Property" Collapsed="true">
     <Position X="6.5" Y="0.5" Width="1.75" />
     <TypeIdentifier>
-      <HashCode>AAAAEAAAKAABChAEAAAAAAAAAABCAEABAAAAAAAAAAA=</HashCode>
+      <HashCode>AAAAEAAAKAABChAFAAAAAAEAAABCAEABAAAAAAAAAAA=</HashCode>
       <FileName>ToCode\Property.cs</FileName>
     </TypeIdentifier>
   </Class>
@@ -112,7 +112,7 @@
   <Class Name="TerminalGuiDesigner.ToCode.CodeDomArgs">
     <Position X="17.25" Y="2.5" Width="1.5" />
     <TypeIdentifier>
-      <HashCode>AAAAAAAAAgAAABAAAAIAAAAAAAAAAAQAEAACAAAAAAA=</HashCode>
+      <HashCode>AAAAAAAAAgAAABAAAAIEAAAAAAAAAAQAEAACAAAAAAA=</HashCode>
       <FileName>ToCode\CodeDomArgs.cs</FileName>
     </TypeIdentifier>
   </Class>
@@ -192,10 +192,62 @@
       <FileName>Operations\OperationFactory.cs</FileName>
     </TypeIdentifier>
   </Class>
+  <Class Name="TerminalGuiDesigner.TTypes">
+    <Position X="11.5" Y="7.75" Width="3.25" />
+    <TypeIdentifier>
+      <HashCode>AAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAA=</HashCode>
+      <FileName>TTypes.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="TerminalGuiDesigner.ToCode.TreeObjectsProperty&lt;T&gt;">
+    <Position X="8.75" Y="7.75" Width="2.25" />
+    <Compartments>
+      <Compartment Name="Methods" Collapsed="true" />
+    </Compartments>
+    <InheritanceLine Type="TerminalGuiDesigner.ToCode.Property" ManuallyRouted="true">
+      <Path>
+        <Point X="7.375" Y="1.191" />
+        <Point X="7.375" Y="1.345" />
+        <Point X="8.398" Y="1.345" />
+        <Point X="8.398" Y="7.159" />
+        <Point X="9.875" Y="7.159" />
+        <Point X="9.875" Y="7.75" />
+      </Path>
+    </InheritanceLine>
+    <TypeIdentifier>
+      <HashCode>BgBAEAAAIAAAAgIEAAAAAAAAAABAAGAAAAAAAAAAAAA=</HashCode>
+      <FileName>ToCode\TreeObjectsProperty.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Class Name="TerminalGuiDesigner.UI.Windows.ArrayEditor" Collapsed="true">
+    <Position X="11.5" Y="9.25" Width="1.5" />
+    <Compartments>
+      <Compartment Name="Fields" Collapsed="true" />
+    </Compartments>
+    <TypeIdentifier>
+      <HashCode>AAAAgAAAACQgAAEEgAggAAQDACBQBABAAIBAEAAAgAQ=</HashCode>
+      <FileName>UI\Windows\ArrayEditor.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="TerminalGuiDesigner.TypeExtensions">
+    <Position X="15" Y="7.75" Width="1.75" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAABAAAQAAAAAAAAAAAAAA=</HashCode>
+      <FileName>TypeExtensions.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="TerminalGuiDesigner.UI.ValueFactory">
+    <Position X="13" Y="9.25" Width="2.5" />
+    <TypeIdentifier>
+      <HashCode>AAAACAEAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAI=</HashCode>
+      <FileName>UI\ValueFactory.cs</FileName>
+    </TypeIdentifier>
+  </Class>
   <Interface Name="TerminalGuiDesigner.Operations.IOperation">
     <Position X="10.75" Y="0.5" Width="1.5" />
     <TypeIdentifier>
-      <HashCode>AAAAAAAAAAAABAAAAAAgABABCAAAAAAAACAAAAAACAA=</HashCode>
+      <HashCode>AAAAAAAAAQAABAAAAAAgABABCAAAAAAAACAAAAAACAA=</HashCode>
       <FileName>Operations\IOperation.cs</FileName>
     </TypeIdentifier>
   </Interface>

--- a/src/ToCode/ICustomPropertySetterCode.cs
+++ b/src/ToCode/ICustomPropertySetterCode.cs
@@ -1,0 +1,6 @@
+﻿namespace TerminalGuiDesigner.ToCode
+{
+    internal interface ICustomPropertySetterCode
+    {
+    }
+}

--- a/src/ToCode/ICustomPropertySetterCode.cs
+++ b/src/ToCode/ICustomPropertySetterCode.cs
@@ -1,6 +1,0 @@
-﻿namespace TerminalGuiDesigner.ToCode
-{
-    internal interface ICustomPropertySetterCode
-    {
-    }
-}

--- a/src/ToCode/ITreeObjectsProperty.cs
+++ b/src/ToCode/ITreeObjectsProperty.cs
@@ -1,0 +1,6 @@
+﻿namespace TerminalGuiDesigner.ToCode;
+
+public interface ITreeObjectsProperty
+{
+    public bool IsEmpty();
+}

--- a/src/ToCode/ITreeObjectsProperty.cs
+++ b/src/ToCode/ITreeObjectsProperty.cs
@@ -6,6 +6,13 @@
 public interface ITreeObjectsProperty
 {
     /// <summary>
+    /// Returns True if the T type the property was constructed with is well
+    /// supported by the designer (i.e. user can pick objects for their tree).
+    /// </summary>
+    /// <returns></returns>
+    bool IsSupported();
+
+    /// <summary>
     /// Returns true if the collection currently held on the property is empty
     /// </summary>
     /// <returns></returns>

--- a/src/ToCode/ITreeObjectsProperty.cs
+++ b/src/ToCode/ITreeObjectsProperty.cs
@@ -1,6 +1,13 @@
 ﻿namespace TerminalGuiDesigner.ToCode;
 
+/// <summary>
+/// Interface for generic class <see cref="TreeObjectsProperty{T}"/>
+/// </summary>
 public interface ITreeObjectsProperty
 {
+    /// <summary>
+    /// Returns true if the collection currently held on the property is empty
+    /// </summary>
+    /// <returns></returns>
     public bool IsEmpty();
 }

--- a/src/ToCode/TreeObjectsProperty.cs
+++ b/src/ToCode/TreeObjectsProperty.cs
@@ -105,8 +105,18 @@ public class TreeObjectsProperty<T> : Property, ITreeObjectsProperty where T : c
     private static CodeExpression TreeBuilderForFileSystemInfo()
     {
         return new CodeSnippetExpression("""
-                                            new Terminal.Gui.DelegateTreeBuilder<System.IO.FileSystemInfo>(
-                                                (p) => p is System.IO.DirectoryInfo d ? d.GetFileSystemInfos() : System.Linq.Enumerable.Empty<System.IO.FileSystemInfo>())
+                                                                        
+                                            new Terminal.Gui.DelegateTreeBuilder<System.IO.FileSystemInfo>((p) =>
+                                            {
+                                                try
+                                                {
+                                                    return p is System.IO.DirectoryInfo d ? d.GetFileSystemInfos() : System.Linq.Enumerable.Empty<System.IO.FileSystemInfo>();
+                                                }
+                                                catch (Exception)
+                                                {
+                                                    return System.Linq.Enumerable.Empty<System.IO.FileSystemInfo>();
+                                                }
+                                            });
                                             """);
                     }
 

--- a/src/ToCode/TreeObjectsProperty.cs
+++ b/src/ToCode/TreeObjectsProperty.cs
@@ -117,7 +117,17 @@ public class TreeObjectsProperty<T> : Property, ITreeObjectsProperty where T : c
     /// <exception cref="NotSupportedException">Always thrown</exception>
     public override string GetLhs()
     {
-        throw new NotSupportedException("This property requires ");
+        throw new NotSupportedException("This property does its own code gen in ToCode");
+    }
+
+    /// <summary>
+    /// Not implemented by this class
+    /// </summary>
+    /// <returns></returns>
+    /// <exception cref="NotSupportedException">Always thrown</exception>
+    public override CodeExpression GetRhs()
+    {
+        throw new NotSupportedException("This property does its own code gen in ToCode");
     }
 
     /// <inheritdoc/>

--- a/src/ToCode/TreeObjectsProperty.cs
+++ b/src/ToCode/TreeObjectsProperty.cs
@@ -125,4 +125,10 @@ public class TreeObjectsProperty<T> : Property, ITreeObjectsProperty where T : c
     {
         return !value.Any();
     }
+
+    /// <inheritdoc/>
+    public bool IsSupported()
+    {
+        return treeBuilders.ContainsKey(typeof(T));
+    }
 }

--- a/src/ToCode/TreeObjectsProperty.cs
+++ b/src/ToCode/TreeObjectsProperty.cs
@@ -1,0 +1,69 @@
+﻿using System.CodeDom;
+using System.Reflection;
+using System.Runtime.Intrinsics;
+using Terminal.Gui;
+using TerminalGuiDesigner.FromCode;
+
+namespace TerminalGuiDesigner.ToCode;
+
+public class TreeObjectsProperty<T> : Property
+{
+    public List<T> Value { get; private set; } = new List<T>();
+
+    public TreeObjectsProperty(Design design)
+        : base(
+        design,
+        typeof(Design).GetProperty(nameof(TreeView.Objects)) ?? throw new MissingFieldException("Expected property was missing from TreeView"))
+    {
+    }
+
+    public override string GetHumanReadableName()
+    {
+        return "Objects";
+    }
+
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        return $"{this.GetHumanReadableName()}:{this.Value.Count} objects";
+    }
+
+    public override void SetValue(object? value)
+    {
+        this.Value = (List<T>)(value ?? new List<T>());
+    }
+
+    public override object GetValue()
+    {
+        return this.Value;
+    }
+
+    public override void ToCode(CodeDomArgs args)
+    {
+        // Create statement like this
+        //tree1.AddObjects(new List<FileSystemInfo>() { new DirectoryInfo("c:\\") });
+
+
+        var call = new CodeMethodInvokeExpression();
+        call.Method.TargetObject = new CodeFieldReferenceExpression(
+            new CodeThisReferenceExpression(),
+            $"this.{this.Design.FieldName}");
+
+        call.Method.MethodName = nameof(TreeView.AddObjects);
+
+        var newListStatement = new CodeObjectCreateExpression(typeof(T),
+             new CodeArrayCreateExpression(
+            new CodeTypeReference(typeof(string)),
+            Value.Select(v => TTypes.ToCode(args, Design, v)).ToArray()));
+
+        call.Parameters.Add(newListStatement);
+
+        args.InitMethod.Statements.Add(call);
+    }
+
+    public override string GetLhs()
+    {
+        throw new NotSupportedException("This property requires ");
+    }
+
+}

--- a/src/ToCode/TreeObjectsProperty.cs
+++ b/src/ToCode/TreeObjectsProperty.cs
@@ -3,9 +3,13 @@ using Terminal.Gui;
 
 namespace TerminalGuiDesigner.ToCode;
 
-public class TreeObjectsProperty<T> : Property where T : class
+/// <summary>
+/// <see cref="Property"/> for storing, editing and code gen for TreeView&lt;T&gt;.Options.
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public class TreeObjectsProperty<T> : Property, ITreeObjectsProperty where T : class
 {
-    public List<T> Value { get; private set; } = new List<T>();
+    public List<T> Value { get; private set; }
     readonly TreeView<T> treeView;
 
     Dictionary<Type,Func<CodeExpression>> treeBuilders = new Dictionary<Type, Func<CodeExpression>>()
@@ -21,6 +25,7 @@ public class TreeObjectsProperty<T> : Property where T : class
               ?? throw new MissingFieldException("Expected property was missing from TreeView"))
     {
         treeView = (TreeView<T>)design.View;
+        Value = new List<T>(treeView.Objects);
     }
 
     public override string GetHumanReadableName()
@@ -69,8 +74,6 @@ public class TreeObjectsProperty<T> : Property where T : class
 
         args.InitMethod.Statements.Add(call);
 
-
-
         // Now also create TreeBuilder if its a known Type we can handle
         if(treeBuilders.ContainsKey(typeof(T)))
         {
@@ -101,4 +104,8 @@ public class TreeObjectsProperty<T> : Property where T : class
         throw new NotSupportedException("This property requires ");
     }
 
+    public bool IsEmpty()
+    {
+        return !Value.Any();
+    }
 }

--- a/src/ToCode/TreeObjectsProperty.cs
+++ b/src/ToCode/TreeObjectsProperty.cs
@@ -6,14 +6,15 @@ using TerminalGuiDesigner.FromCode;
 
 namespace TerminalGuiDesigner.ToCode;
 
-public class TreeObjectsProperty<T> : Property
+public class TreeObjectsProperty<T> : Property where T : class
 {
     public List<T> Value { get; private set; } = new List<T>();
 
     public TreeObjectsProperty(Design design)
         : base(
         design,
-        typeof(Design).GetProperty(nameof(TreeView.Objects)) ?? throw new MissingFieldException("Expected property was missing from TreeView"))
+        typeof(TreeView<T>).GetProperty(nameof(TreeView<T>.Objects)) 
+              ?? throw new MissingFieldException("Expected property was missing from TreeView"))
     {
     }
 

--- a/src/TreeViewExtensions.cs
+++ b/src/TreeViewExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terminal.Gui;
+using TerminalGuiDesigner.ToCode;
+
+namespace TerminalGuiDesigner
+{
+    /// <summary>
+    /// Extension methods for <see cref="TreeView"/>
+    /// </summary>
+    public static class TreeViewExtensions
+    {
+        /// <summary>
+        /// For a given TreeView, returns true if there are any Objects defined in it.
+        /// </summary>
+        /// <param name="tv"></param>
+        /// <returns></returns>
+        /// <exception cref="NotSupportedException">If <paramref name="tv"/> is not a TreeView (or TreeView&lt;&gt; implementation)</exception>
+        /// <exception cref="Exception">If Terminal.Gui API changes have been made that break reflection</exception>
+        public static bool IsEmpty(this View tv)
+        {
+            if (tv is TreeView basicTreeView)
+            {
+                return !basicTreeView.Objects.Any();
+            }
+
+            if (!tv.GetType().IsGenericType(typeof(TreeView<>)))
+            {
+                throw new NotSupportedException("Expected Tree View Type to be an implementation of generic class TreeView<>");
+            }
+
+            var d = tv.Data as Design ?? throw new NotSupportedException("View does not have a Design");
+            var prop = (ITreeObjectsProperty)(
+                    d.GetDesignableProperty(nameof(TreeView.Objects))
+                    ?? throw new Exception("View did not have expected Designable property")
+                );
+            return prop.IsEmpty();
+        }
+    }
+}

--- a/src/TreeViewExtensions.cs
+++ b/src/TreeViewExtensions.cs
@@ -32,11 +32,18 @@ namespace TerminalGuiDesigner
                 throw new NotSupportedException("Expected Tree View Type to be an implementation of generic class TreeView<>");
             }
 
+
+
             var d = tv.Data as Design ?? throw new NotSupportedException("View does not have a Design");
-            var prop = (ITreeObjectsProperty)(
-                    d.GetDesignableProperty(nameof(TreeView.Objects))
-                    ?? throw new Exception("View did not have expected Designable property")
-                );
+
+            var prop = (ITreeObjectsProperty?)d.GetDesignableProperty(nameof(TreeView.Objects));
+
+            if(prop == null)
+            {
+                // Options are not designable for this T type so TreeView must be empty
+                return true;
+            }
+
             return prop.IsEmpty();
         }
     }

--- a/src/TypeExtensions.cs
+++ b/src/TypeExtensions.cs
@@ -27,6 +27,12 @@ namespace TerminalGuiDesigner
             {
                 return type.GetGenericArguments().Single();
             }
+            
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            {
+                return type.GetGenericArguments().Single();
+            }
+
 
             return null;
         }

--- a/src/TypeExtensions.cs
+++ b/src/TypeExtensions.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Terminal.Gui;
 
 namespace TerminalGuiDesigner
 {
@@ -35,6 +36,18 @@ namespace TerminalGuiDesigner
 
 
             return null;
+        }
+
+        /// <summary>
+        /// Returns true if <paramref name="type"/> is an implementation of a generic parent
+        /// type <paramref name="genericParentHypothesis"/>.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="genericParentHypothesis">Generic parent e.g. <see langword="typeof"/>(TreeView&lt;&gt;)</param>
+        /// <returns></returns>
+        public static bool IsGenericType(this Type type, Type genericParentHypothesis)
+        {
+            return type.IsGenericType && type.GetGenericTypeDefinition() == genericParentHypothesis;
         }
     }
 }

--- a/src/TypeExtensions.cs
+++ b/src/TypeExtensions.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Terminal.Gui;
 
 namespace TerminalGuiDesigner
 {
+    /// <summary>
+    /// Extensions for the <see cref="Type"/> class.
+    /// </summary>
     public static class TypeExtensions
     {
         /// <summary>

--- a/src/TypeExtensions.cs
+++ b/src/TypeExtensions.cs
@@ -27,7 +27,7 @@ namespace TerminalGuiDesigner
                 return type.GetGenericArguments().Single();
             }
             
-            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            if (type.IsGenericType(typeof(IEnumerable<>)))
             {
                 return type.GetGenericArguments().Single();
             }

--- a/src/UI/Editor.cs
+++ b/src/UI/Editor.cs
@@ -240,7 +240,7 @@ public class Editor : Toplevel
     }
 
     /// <summary>
-    /// Event handler for <see cref="Application.KeyPressed"/>.
+    /// Event handler for <see cref="Application.KeyDown"/>.
     /// </summary>
     /// <param name="key">The key pressed.</param>
     /// <returns>True if key is handled.</returns>

--- a/src/UI/ValueFactory.cs
+++ b/src/UI/ValueFactory.cs
@@ -161,7 +161,7 @@ namespace TerminalGuiDesigner.UI
             }
             else
             if (
-                type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>) ||
+                type.IsGenericType(typeof(IEnumerable<>)) ||
                 type.IsAssignableTo(typeof(IList))
                 )
             {

--- a/src/UI/ValueFactory.cs
+++ b/src/UI/ValueFactory.cs
@@ -283,6 +283,17 @@ namespace TerminalGuiDesigner.UI
                 var fd = new FileDialog();
                 fd.AllowsMultipleSelection = false;
 
+
+                int answer = ChoicesDialog.Query(propertyName, $"Directory or File?", "Directory", "File", "Cancel");
+
+                if (answer < 0 || answer >= 2)
+                {
+                    return false;
+                }
+                bool pickDir = answer == 0;
+
+                fd.OpenMode = pickDir ? OpenMode.Directory : OpenMode.File;
+
                 Application.Run(fd);
                 if (fd.Canceled || string.IsNullOrWhiteSpace(fd.Path))
                 {
@@ -290,7 +301,7 @@ namespace TerminalGuiDesigner.UI
                 }
                 else
                 {
-                    newValue = IsPathDirectory(fd.Path) ?
+                    newValue = pickDir ? 
                         new DirectoryInfo(fd.Path) : new FileInfo(fd.Path);
                     return true;
                 }
@@ -405,34 +416,6 @@ namespace TerminalGuiDesigner.UI
                 newValue = null;
                 return false;
             }
-        }
-
-        /// <summary>
-        /// Returns true if path is to a directory.
-        /// Thanks: https://stackoverflow.com/a/19596821/4824531
-        /// </summary>
-        /// <param name="path"></param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentNullException"></exception>
-        static bool IsPathDirectory(string path)
-        {
-            if (path == null) throw new ArgumentNullException("path");
-            path = path.Trim();
-
-            if (Directory.Exists(path))
-                return true;
-
-            if (File.Exists(path))
-                return false;
-
-            // neither file nor directory exists. guess intention
-
-            // if has trailing slash then it's a directory
-            if (new[] { Path.DirectorySeparatorChar,Path.AltDirectorySeparatorChar}.Any(x => path.EndsWith(x)))
-                return true; // ends with slash
-
-            // if has extension then its a file; directory otherwise
-            return string.IsNullOrWhiteSpace(Path.GetExtension(path));
-        }
+        }        
     }
 }

--- a/src/UI/Windows/ArrayEditor.cs
+++ b/src/UI/Windows/ArrayEditor.cs
@@ -27,6 +27,13 @@ namespace TerminalGuiDesigner.UI.Windows {
         /// </summary>
         public IList Result { get; private set; }
 
+        /// <summary>
+        /// Creates a new instance of the editor configured to build lists of <paramref name="elementType"/>
+        /// and showing initial values held in <paramref name="oldValue"/> (if any).
+        /// </summary>
+        /// <param name="design"></param>
+        /// <param name="elementType"></param>
+        /// <param name="oldValue"></param>
         public ArrayEditor(Design design, Type elementType, IList oldValue) {
             InitializeComponent();
             this.design = design;

--- a/src/UI/Windows/DimEditor.cs
+++ b/src/UI/Windows/DimEditor.cs
@@ -36,6 +36,7 @@ public partial class DimEditor : Dialog
     /// Creates a new instance of the <see cref="DimEditor"/> class.
     /// </summary>
     /// <param name="design"></param>
+    /// <param name="oldValue">Old value (if editing an existing instance)</param>
     public DimEditor(Design design, Dim oldValue) {
         InitializeComponent();
         

--- a/src/UI/Windows/SliderOptionEditor.cs
+++ b/src/UI/Windows/SliderOptionEditor.cs
@@ -17,7 +17,14 @@ namespace TerminalGuiDesigner.UI.Windows {
         private readonly Type genericTypeArgument;
         private readonly Type sliderOptionType;
 
+        /// <summary>
+        /// True if the dialog was canceled before completing
+        /// </summary>
         public bool Cancelled { get; internal set; } = true;
+        
+        /// <summary>
+        /// The resulting value as configured by the user
+        /// </summary>
         public object Result { get; internal set; }
 
         /// <summary>
@@ -25,6 +32,7 @@ namespace TerminalGuiDesigner.UI.Windows {
         /// where T is of <see cref="Type"/> <paramref name="genericTypeArgument"/>.
         /// </summary>
         /// <param name="genericTypeArgument">The T Type of the <see cref="SliderOption{T}"/> you want to design</param>
+        /// <param name="oldValue">Previous value (if editing an existing instance).</param>
         public SliderOptionEditor(Type genericTypeArgument, object? oldValue) {
             InitializeComponent();
 

--- a/src/ViewExtensions.cs
+++ b/src/ViewExtensions.cs
@@ -232,6 +232,11 @@ public static class ViewExtensions
             return true;
         }
 
+        if(v.GetType().IsGenericType(typeof(TreeView<>)))
+        {
+            return TreeViewExtensions.IsEmpty(v);
+        }
+
         return false;
     }
 

--- a/src/ViewFactory.cs
+++ b/src/ViewFactory.cs
@@ -203,9 +203,12 @@ public static class ViewFactory
                 SetDefaultDimensions( newView, width ?? 16, height ?? 5 );
                 break;
             case TreeView<FileSystemInfo> fstv:
-
                 fstv.TreeBuilder = new DelegateTreeBuilder<FileSystemInfo>(
                     (p) => p is DirectoryInfo d ? d.GetFileSystemInfos() : Enumerable.Empty<FileSystemInfo>());
+                SetDefaultDimensions(newView, width ?? 16, height ?? 5);
+                break;
+            case TreeView<object> fstv:
+                fstv.TreeBuilder = new DelegateTreeBuilder<object>(o => Enumerable.Empty<object>());
                 SetDefaultDimensions(newView, width ?? 16, height ?? 5);
                 break;
             case ScrollView sv:

--- a/src/ViewFactory.cs
+++ b/src/ViewFactory.cs
@@ -202,6 +202,12 @@ public static class ViewFactory
             case TreeView:
                 SetDefaultDimensions( newView, width ?? 16, height ?? 5 );
                 break;
+            case TreeView<FileSystemInfo> fstv:
+
+                fstv.TreeBuilder = new DelegateTreeBuilder<FileSystemInfo>(
+                    (p) => p is DirectoryInfo d ? d.GetFileSystemInfos() : Enumerable.Empty<FileSystemInfo>());
+                SetDefaultDimensions(newView, width ?? 16, height ?? 5);
+                break;
             case ScrollView sv:
                 sv.ContentSize = new Size( 20, 10 );
                 SetDefaultDimensions(newView, width ?? 10, height ?? 5 );

--- a/src/ViewFactory.cs
+++ b/src/ViewFactory.cs
@@ -203,8 +203,18 @@ public static class ViewFactory
                 SetDefaultDimensions( newView, width ?? 16, height ?? 5 );
                 break;
             case TreeView<FileSystemInfo> fstv:
-                fstv.TreeBuilder = new DelegateTreeBuilder<FileSystemInfo>(
-                    (p) => p is DirectoryInfo d ? d.GetFileSystemInfos() : Enumerable.Empty<FileSystemInfo>());
+                fstv.TreeBuilder = new DelegateTreeBuilder<FileSystemInfo>((p) =>
+                {
+                    try
+                    {
+                        return p is DirectoryInfo d ? d.GetFileSystemInfos() : Enumerable.Empty<FileSystemInfo>();
+                    }
+                    catch (Exception)
+                    {
+                        return Enumerable.Empty<FileSystemInfo>();
+                    }
+                });
+
                 SetDefaultDimensions(newView, width ?? 16, height ?? 5);
                 break;
             case ScrollView sv:

--- a/src/ViewFactory.cs
+++ b/src/ViewFactory.cs
@@ -207,10 +207,6 @@ public static class ViewFactory
                     (p) => p is DirectoryInfo d ? d.GetFileSystemInfos() : Enumerable.Empty<FileSystemInfo>());
                 SetDefaultDimensions(newView, width ?? 16, height ?? 5);
                 break;
-            case TreeView<object> fstv:
-                fstv.TreeBuilder = new DelegateTreeBuilder<object>(o => Enumerable.Empty<object>());
-                SetDefaultDimensions(newView, width ?? 16, height ?? 5);
-                break;
             case ScrollView sv:
                 sv.ContentSize = new Size( 20, 10 );
                 SetDefaultDimensions(newView, width ?? 10, height ?? 5 );

--- a/src/ViewFactory.cs
+++ b/src/ViewFactory.cs
@@ -35,7 +35,6 @@ public static class ViewFactory
         typeof( SaveDialog ),
         typeof( OpenDialog ),
         typeof( ScrollBarView ),
-        typeof( TreeView<> ),
 
         // Theses are special types of view and shouldn't be added manually by user
         typeof( Frame ),
@@ -305,18 +304,4 @@ public static class ViewFactory
         return Create<T>( );
     }
 
-    /// <summary>
-    /// Returns all Types which can be used with generic view of the given <paramref name="viewType"/>.
-    /// </summary>
-    /// <param name="viewType">A generic view type e.g. <see langword="typeof"/>(Slider&lt;&gt;)</param>
-    /// <returns></returns>
-    public static IEnumerable<Type> GetSupportedTTypesForGenericViewOfType(Type viewType)
-    {
-        if(viewType == typeof(Slider<>))
-        {
-            return new[] { typeof(int), typeof(string), typeof(float), typeof(double), typeof(bool) };
-        }
-
-        throw new NotSupportedException($"Generic View {viewType} is not yet supported");
-    }
 }

--- a/tests/Tests.cs
+++ b/tests/Tests.cs
@@ -161,7 +161,7 @@ internal class Tests
     {
         if (type.IsGenericTypeDefinition)
         {
-            var tType = ViewFactory.GetSupportedTTypesForGenericViewOfType(type).First();
+            var tType = TTypes.GetSupportedTTypesForGenericViewOfType(type).First();
             return type.MakeGenericType(tType);
         }
 

--- a/tests/TreeViewTests.cs
+++ b/tests/TreeViewTests.cs
@@ -19,23 +19,26 @@ namespace UnitTests
             {
                 var objectsProperty = d.GetDesignableProperty("Objects");
                 Assert.That(objectsProperty,Is.InstanceOf<TreeObjectsProperty<FileSystemInfo>>());
+                
                 objectsProperty.SetValue(
                     new List<FileSystemInfo>(
                         new FileSystemInfo[] {
                             new DirectoryInfo("/"),
                             new FileInfo("/blah.txt")
                         }));
+
+
+                Assert.That(v.Objects.Count, Is.EqualTo(2));
+
             }, out var viewAfter);
 
-            
-
             Assert.That(viewAfter.Objects.Count, Is.EqualTo(2));
 
             Assert.That(viewAfter.Objects.Count, Is.EqualTo(2));
             Assert.That(viewAfter.Objects.Count, Is.EqualTo(2));
 
-            Assert.That(viewAfter.Objects.ElementAt(0), Is.EqualTo(new DirectoryInfo("/")));
-            Assert.That(viewAfter.Objects.ElementAt(1), Is.EqualTo(new FileInfo("/blah.txt")));
+            Assert.That(viewAfter.Objects.ElementAt(0).ToString(), Is.EqualTo(new DirectoryInfo("/").ToString()));
+            Assert.That(viewAfter.Objects.ElementAt(1).ToString(), Is.EqualTo(new FileInfo("/blah.txt").ToString()));
         }
 
     }

--- a/tests/TreeViewTests.cs
+++ b/tests/TreeViewTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UnitTests
+{
+    internal class TreeViewTests : Tests
+    {
+        [Test]
+        public void TestRoundTrip_TreeView_FileSystemInfo()
+        {
+            Assert.That(
+                TTypes.GetSupportedTTypesForGenericViewOfType(typeof(TreeView<>)),
+                Contains.Item(typeof(FileSystemInfo)));
+
+            var sliderIn = RoundTrip<Dialog, TreeView<FileSystemInfo>>((d, v) =>
+            {
+                var objectsProperty = d.GetDesignableProperty("Objects");
+                Assert.That(objectsProperty,Is.InstanceOf<TreeObjectsProperty<FileSystemInfo>>());
+                objectsProperty.SetValue(
+                    new List<FileSystemInfo>(
+                        new FileSystemInfo[] {
+                            new DirectoryInfo("/"),
+                            new FileInfo("/blah.txt")
+                        }));
+            }, out var viewAfter);
+
+            
+
+            Assert.That(viewAfter.Objects.Count, Is.EqualTo(2));
+
+            Assert.That(viewAfter.Objects.Count, Is.EqualTo(2));
+            Assert.That(viewAfter.Objects.Count, Is.EqualTo(2));
+
+            Assert.That(viewAfter.Objects.ElementAt(0), Is.EqualTo(new DirectoryInfo("/")));
+            Assert.That(viewAfter.Objects.ElementAt(1), Is.EqualTo(new FileInfo("/blah.txt")));
+        }
+
+    }
+}

--- a/tests/TreeViewTests.cs
+++ b/tests/TreeViewTests.cs
@@ -54,11 +54,12 @@
 
             var sliderIn = RoundTrip<Dialog, TreeView<object>>((d, v) =>
             {
+                // Should not be able to pick Objects when T is object
                 var objectsProperty = d.GetDesignableProperty("Objects");
-                Assert.That(objectsProperty, Is.InstanceOf<TreeObjectsProperty<object>>());
                 Assert.That(v.TreeBuilder, Is.Null);
 
                 Assert.That(v.IsBorderlessContainerView, Is.True);
+
 
             }, out var viewAfter);
 

--- a/tests/TreeViewTests.cs
+++ b/tests/TreeViewTests.cs
@@ -13,7 +13,10 @@
             {
                 var objectsProperty = d.GetDesignableProperty("Objects");
                 Assert.That(objectsProperty,Is.InstanceOf<TreeObjectsProperty<FileSystemInfo>>());
-                
+
+                // When TreeView is empty it is invisible, so should show border
+                Assert.That(v.IsBorderlessContainerView, Is.True);
+
                 objectsProperty.SetValue(
                     new List<FileSystemInfo>(
                         new FileSystemInfo[] {
@@ -21,9 +24,11 @@
                             new FileInfo("/blah.txt")
                         }));
 
-
                 Assert.That(v.Objects.Count, Is.EqualTo(2));
                 Assert.That(v.TreeBuilder, Is.Not.Null);
+
+                // Once tree view is no longer empty it can loose its 'invisible' border
+                Assert.That(v.IsBorderlessContainerView, Is.False);
 
             }, out var viewAfter);
 
@@ -36,6 +41,29 @@
             Assert.That(viewAfter.Objects.ElementAt(0).ToString(), Is.EqualTo(new DirectoryInfo("/").ToString()));
             Assert.That(viewAfter.Objects.ElementAt(1).ToString(), Is.EqualTo(new FileInfo("/blah.txt").ToString()));
             Assert.That(viewAfter.TreeBuilder, Is.Not.Null);
+
+            Assert.That(viewAfter.IsBorderlessContainerView, Is.False);
+        }
+
+        [Test]
+        public void TestRoundTrip_TreeView_Object()
+        {
+            Assert.That(
+                TTypes.GetSupportedTTypesForGenericViewOfType(typeof(TreeView<>)),
+                Contains.Item(typeof(object)));
+
+            var sliderIn = RoundTrip<Dialog, TreeView<object>>((d, v) =>
+            {
+                var objectsProperty = d.GetDesignableProperty("Objects");
+                Assert.That(objectsProperty, Is.InstanceOf<TreeObjectsProperty<object>>());
+                Assert.That(v.TreeBuilder, Is.Null);
+
+                Assert.That(v.IsBorderlessContainerView, Is.True);
+
+            }, out var viewAfter);
+
+            Assert.That(viewAfter.TreeBuilder, Is.Null);
+            Assert.That(viewAfter.IsBorderlessContainerView, Is.True);
         }
     }
 }

--- a/tests/TreeViewTests.cs
+++ b/tests/TreeViewTests.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace UnitTests
+﻿namespace UnitTests
 {
     internal class TreeViewTests : Tests
     {
@@ -29,8 +23,10 @@ namespace UnitTests
 
 
                 Assert.That(v.Objects.Count, Is.EqualTo(2));
+                Assert.That(v.TreeBuilder, Is.Not.Null);
 
             }, out var viewAfter);
+
 
             Assert.That(viewAfter.Objects.Count, Is.EqualTo(2));
 
@@ -39,7 +35,7 @@ namespace UnitTests
 
             Assert.That(viewAfter.Objects.ElementAt(0).ToString(), Is.EqualTo(new DirectoryInfo("/").ToString()));
             Assert.That(viewAfter.Objects.ElementAt(1).ToString(), Is.EqualTo(new FileInfo("/blah.txt").ToString()));
+            Assert.That(viewAfter.TreeBuilder, Is.Not.Null);
         }
-
     }
 }

--- a/tests/ViewFactoryTests.cs
+++ b/tests/ViewFactoryTests.cs
@@ -275,7 +275,6 @@ internal class ViewFactoryTests
             typeof( SaveDialog ),
             typeof( OpenDialog ),
             typeof( ScrollBarView ),
-            typeof( TreeView<> ),
             typeof( Frame ),
             typeof( Wizard ),
             typeof( WizardStep )


### PR DESCRIPTION
Fixes #267

![tree-view-t](https://github.com/gui-cs/TerminalGuiDesigner/assets/31306100/9ddf37bf-1928-4e02-881d-443545e27785)

_Adding TreeView\<object> then TreeView\<FileSystemInfo> to a Window (with save/open)_

<details>
  <summary>Designer.cs Code</summary>

```csharp
//------------------------------------------------------------------------------

//  <auto-generated>
//      This code was generated by:
//        TerminalGuiDesigner v1.1.0.0
//      Changes to this file may cause incorrect behavior and will be lost if
//      the code is regenerated.
//  </auto-generated>
// -----------------------------------------------------------------------------
namespace YourNamespace {
    using System;
    using Terminal.Gui;
    using System.Collections;
    using System.Collections.Generic;
    
    
    public partial class MyView : Terminal.Gui.Window {
        
        private Terminal.Gui.TreeView<object> treeView1;
        
        private Terminal.Gui.TreeView<System.IO.FileSystemInfo> treeView2;
        
        private void InitializeComponent() {
            this.treeView2 = new Terminal.Gui.TreeView<System.IO.FileSystemInfo>();
            this.treeView1 = new Terminal.Gui.TreeView<object>();
            this.Width = Dim.Fill(0);
            this.Height = Dim.Fill(0);
            this.X = 0;
            this.Y = 0;
            this.Visible = true;
            this.Modal = false;
            this.TextAlignment = Terminal.Gui.TextAlignment.Left;
            this.Title = "";
            this.treeView1.Width = 21;
            this.treeView1.Height = 12;
            this.treeView1.X = 14;
            this.treeView1.Y = 4;
            this.treeView1.Visible = true;
            this.treeView1.Data = "treeView1";
            this.treeView1.Text = "";
            this.treeView1.TextAlignment = Terminal.Gui.TextAlignment.Left;
            this.treeView1.Style.CollapseableSymbol = new System.Text.Rune('-');
            this.treeView1.Style.ColorExpandSymbol = false;
            this.treeView1.Style.ExpandableSymbol = new System.Text.Rune('+');
            this.treeView1.Style.InvertExpandSymbolColors = false;
            this.treeView1.Style.LeaveLastRow = false;
            this.treeView1.Style.ShowBranchLines = true;
            this.Add(this.treeView1);
            this.treeView2.Width = 42;
            this.treeView2.Height = 13;
            this.treeView2.X = 38;
            this.treeView2.Y = 5;
            this.treeView2.Visible = true;
            this.treeView2.Data = "treeView2";
            this.treeView2.Text = "";
            this.treeView2.TextAlignment = Terminal.Gui.TextAlignment.Left;
            this.treeView2.Style.CollapseableSymbol = new System.Text.Rune('-');
            this.treeView2.Style.ColorExpandSymbol = false;
            this.treeView2.Style.ExpandableSymbol = new System.Text.Rune('+');
            this.treeView2.Style.InvertExpandSymbolColors = false;
            this.treeView2.Style.LeaveLastRow = false;
            this.treeView2.Style.ShowBranchLines = true;
            this.treeView2.AddObjects(new System.IO.FileSystemInfo[] {
                        new System.IO.DirectoryInfo("D:\\Repos\\TerminalGuiDesigner\\src\\bin\\Debug\\net8.0"),
                        new System.IO.FileInfo("D:\\Repos\\TerminalGuiDesigner\\src\\bin\\Debug\\net8.0\\Basic.Reference.Assemblies.Net7" +
                                "0.dll"),
                        new System.IO.FileInfo("D:\\Repos\\TerminalGuiDesigner\\src\\bin\\Debug\\net8.0\\Basic.Reference.Assemblies.Net8" +
                                "0.dll")});
            this.treeView2.TreeBuilder = new Terminal.Gui.DelegateTreeBuilder<System.IO.FileSystemInfo>(
    (p) => p is System.IO.DirectoryInfo d ? d.GetFileSystemInfos() : System.Linq.Enumerable.Empty<System.IO.FileSystemInfo>());
            this.Add(this.treeView2);
        }
    }
}

```
</details>

We now have:
- [Slider<T> support](https://github.com/gui-cs/TerminalGuiDesigner/pull/271) (added in #271)
- `TableView<T>` Support (this PR).

This is probably a good place to chat about any refactoring and future proofing of this functionality

User defined Types (e.g. `MyGameObject`) are currently off the cards but should be kept in mind as a future goal.

### Use Case
As a TerminalGuiDesigner user I want to be able to add any of the core generic views. 
- When I add the view I should be asked what T type I want
- Code gen should work
- I should be able to edit relevant properties (e.g. Options in a Slider, Objects in a TreeView) where it is sensible
- I understand that there are limitations to object selection e.g. I cant edit the objects in a `TreeView<object>`.

### Current Implementation
Currently things are a bit all over the place so we need some tidy up.

Classes I like:
`TTypes` - Describes what Types can be picked for `T` in a given generic View

For any given T type we need:
- to know what generic Views it can be selected for (currently in `TTypes.GetSupportedTTypesForGenericViewOfType`)
- explicit code to describe how to 'pick a value' (currently in `ValueFactory`
- `ToCode` that can represent the value being instantiated (currently in `TTypes.ToCode`)
- TreeBuilder codegen (if applicable)


![image](https://github.com/gui-cs/TerminalGuiDesigner/assets/31306100/bb3a6c8a-d3ad-4289-bafd-d7f7b9c4a8ab)
