### PR TITLE
Update to latest v2 branch to 2.0.0-v2-develop.2168

### DIFF
--- a/src/ArrayExtensions.cs
+++ b/src/ArrayExtensions.cs
@@ -1,3 +1,7 @@
+using System.Collections;
+using System.Collections.ObjectModel;
+using Terminal.Gui;
+
 namespace TerminalGuiDesigner;
 
 /// <summary>
@@ -26,4 +30,23 @@ public static class ArrayExtensions
 
         return toReturn;
     }
+    
+    public static IListDataSource ToListDataSource(this IEnumerable enumerable)
+    {
+        // Get the type of the elements
+        var elementType = enumerable.GetType().GetElementType() ?? enumerable.GetType().GetGenericArguments().FirstOrDefault();
+        if (elementType == null)
+        {
+            throw new Exception("Unable to get element type for collection");
+        }
+
+        // Convert the enumerable to an ObservableCollection<T>
+        var observableCollectionType = typeof(ObservableCollection<>).MakeGenericType(elementType);
+        var list = Activator.CreateInstance(observableCollectionType, enumerable);
+
+        // Create an instance of ListWrapper<T>
+        var listWrapperType = typeof(ListWrapper<>).MakeGenericType(elementType);
+        return (IListDataSource)Activator.CreateInstance(listWrapperType, list);
+    }
+
 }

--- a/src/Design.cs
+++ b/src/Design.cs
@@ -623,7 +623,7 @@ public class Design
             return;
         }
 
-        if (e == Key.Tab || e == Key.Tab.WithShift)
+        if (e == Key.Tab || e == Key.Tab.WithShift || e == Key.Esc || e == Application.QuitKey)
         {
             e.Handled = false;
             return;

--- a/src/Design.cs
+++ b/src/Design.cs
@@ -750,7 +750,7 @@ public class Design
 
         if (this.View is CheckBox)
         {
-            yield return this.CreateProperty(nameof(CheckBox.Checked));
+            yield return this.CreateProperty(nameof(CheckBox.CheckedState));
         }
 
         if (this.View is ListView lv)

--- a/src/Design.cs
+++ b/src/Design.cs
@@ -214,14 +214,14 @@ public class Design
         {
             // prevent control from responding to events
             txt.MouseClick += this.SuppressNativeClickEvents;
-            txt.KeyDown += (s, e) => e.Handled = true;
+            txt.KeyDown += this.SuppressNativeKeyboardEvents;
         }
 
         if (subView is TextField tf)
         {
             // prevent control from responding to events
             tf.MouseClick += this.SuppressNativeClickEvents;
-            tf.KeyDown += (s, e) => e.Handled = true;
+            tf.KeyDown += SuppressNativeKeyboardEvents;
         }
 
         if (subView is TreeView tree)
@@ -614,6 +614,22 @@ public class Design
     {
         // Suppress everything except single click (selection)
         obj.Handled = obj.MouseEvent.Flags != MouseFlags.Button1Clicked;
+    }
+
+    private void SuppressNativeKeyboardEvents(object? sender, Key e)
+    {
+        if (sender == null)
+        {
+            return;
+        }
+
+        if (e == Key.Tab || e == Key.Tab.WithShift)
+        {
+            e.Handled = false;
+            return;
+        }
+
+        e.Handled = true;
     }
 
     private void RegisterCheckboxDesignTimeChanges(CheckBox cb)

--- a/src/Design.cs
+++ b/src/Design.cs
@@ -700,7 +700,9 @@ public class Design
 
         if (this.View is TextView)
         {
-            yield return this.CreateProperty(nameof(TextView.AllowsTab));
+            // Do not allow tab at design time so that we don't get stuck in the View (adding more tabs each time!)
+            // But let user edit if they want
+            yield return this.CreateSuppressedProperty(nameof(TextView.AllowsTab), false);
             yield return this.CreateProperty(nameof(TextView.AllowsReturn));
             yield return this.CreateProperty(nameof(TextView.WordWrap));
         }

--- a/src/Design.cs
+++ b/src/Design.cs
@@ -167,11 +167,6 @@ public class Design
     /// <returns>A new <see cref="Design"/> wrapper wrapping <paramref name="subView"/>.</returns>
     public Design CreateSubControlDesign(string name, View subView)
     {
-        // HACK: if you don't pull the label out first it complains that you cant set Focusable to true
-        // on the Label because its super is not focusable :(
-        var super = subView.SuperView;
-        super?.Remove(subView);
-
         // all views can be focused so that they can be edited
         // or deleted etc
         subView.CanFocus = true;
@@ -249,9 +244,7 @@ public class Design
                 tree.AddObject(new TreeNode($"Example Leaf {l}"));
             }
         }
-
-        super?.Add(subView);
-
+        
         var d = new Design(this.SourceCode, name, subView);
         return d;
     }

--- a/src/Design.cs
+++ b/src/Design.cs
@@ -651,8 +651,6 @@ public class Design
 
         yield return this.CreateSuppressedProperty(nameof(this.View.Visible), true);
 
-        yield return this.CreateSuppressedProperty(nameof(this.View.Arrangement), ViewArrangement.Movable);
-
         yield return new ColorSchemeProperty(this);
 
         // its important that this comes before Text because

--- a/src/Design.cs
+++ b/src/Design.cs
@@ -229,12 +229,6 @@ public class Design
             tf.KeyDown += (s, e) => e.Handled = true;
         }
 
-        if (subView is Window w)
-        {
-            // prevent control from responding to events
-            w.Arrangement = ViewArrangement.Fixed;
-        }
-
         if (subView is TreeView tree)
         {
             tree.AddObject(new TreeNode("Example Branch 1")
@@ -656,6 +650,8 @@ public class Design
         yield return this.CreateProperty(nameof(this.View.Y));
 
         yield return this.CreateSuppressedProperty(nameof(this.View.Visible), true);
+
+        yield return this.CreateSuppressedProperty(nameof(this.View.Arrangement), ViewArrangement.Fixed);
 
         yield return new ColorSchemeProperty(this);
 

--- a/src/Design.cs
+++ b/src/Design.cs
@@ -229,6 +229,12 @@ public class Design
             tf.KeyDown += (s, e) => e.Handled = true;
         }
 
+        if (subView is Window w)
+        {
+            // prevent control from responding to events
+            w.Arrangement = ViewArrangement.Fixed;
+        }
+
         if (subView is TreeView tree)
         {
             tree.AddObject(new TreeNode("Example Branch 1")

--- a/src/EnumerableExtensions.cs
+++ b/src/EnumerableExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TerminalGuiDesigner
+{
+    internal static class EnumerableExtensions
+    {
+        public static ObservableCollection<T> ToListObs<T>(this IEnumerable<T> e)
+        {
+            return new ObservableCollection<T>(e);
+        }
+    }
+}

--- a/src/FromCode/CodeToView.cs
+++ b/src/FromCode/CodeToView.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -160,6 +161,7 @@ public class CodeToView
             MetadataReference.CreateFromFile(typeof(System.Linq.Enumerable).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(MarshalByValueComponent).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(ObservableCollection<string>).Assembly.Location),
 
             // New assemblies required by Terminal.Gui version 2
             MetadataReference.CreateFromFile(typeof(Size).Assembly.Location),

--- a/src/MenuTracker.cs
+++ b/src/MenuTracker.cs
@@ -195,7 +195,7 @@ public class MenuTracker
         {
             Title = bar.Title,
             Data = bar.Data,
-            Shortcut = bar.Shortcut
+            ShortcutKey = bar.ShortcutKey
         };
 
         return true;

--- a/src/Operations/MenuOperations/MoveMenuItemRightOperation.cs
+++ b/src/Operations/MenuOperations/MoveMenuItemRightOperation.cs
@@ -110,7 +110,7 @@ public class MoveMenuItemRightOperation : MenuItemOperation
 
         var added = new MenuBarItem(children[idx].Title, new MenuItem[0], null);
         added.Data = children[idx].Data;
-        added.Shortcut = children[idx].Shortcut;
+        added.ShortcutKey = children[idx].ShortcutKey;
 
         children.RemoveAt(idx);
         children.Insert(idx, added);

--- a/src/Operations/StatusBarOperations/AddStatusItemOperation.cs
+++ b/src/Operations/StatusBarOperations/AddStatusItemOperation.cs
@@ -4,9 +4,9 @@ using TerminalGuiDesigner.Operations.Generics;
 namespace TerminalGuiDesigner.Operations.StatusBarOperations
 {
     /// <summary>
-    /// Operation for adding a new <see cref="StatusItem"/> to a <see cref="StatusBar"/>.
+    /// Operation for adding a new <see cref="Shortcut"/> to a <see cref="StatusBar"/>.
     /// </summary>
-    public class AddStatusItemOperation : AddOperation<StatusBar, StatusItem>
+    public class AddStatusItemOperation : AddOperation<StatusBar, Shortcut>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AddStatusItemOperation"/> class.
@@ -15,10 +15,10 @@ namespace TerminalGuiDesigner.Operations.StatusBarOperations
         /// <param name="name">Name for the new item created or null to prompt user.</param>
         public AddStatusItemOperation(Design design, string? name)
             : base(
-                  (d) => d.Items,
-                  (d, v) => d.Items = v,
+                  (d) => d.GetShortcuts(),
+                  (d, v) => d.SetShortcuts(v),
                   (v) => v.Title.ToString() ?? Operation.Unnamed,
-                  (d, name) => { return new StatusItem(KeyCode.Null, name, null); },
+                  (d, name) => { return new Shortcut(KeyCode.Null, name, null); },
                   design,
                   name)
         {

--- a/src/Operations/StatusBarOperations/MoveStatusItemOperation.cs
+++ b/src/Operations/StatusBarOperations/MoveStatusItemOperation.cs
@@ -6,18 +6,18 @@ namespace TerminalGuiDesigner.Operations.StatusBarOperations
     /// <summary>
     /// Moves a <see cref="StatusItem"/> on a <see cref="StatusBar"/> left or right.
     /// </summary>
-    public class MoveStatusItemOperation : MoveOperation<StatusBar, StatusItem>
+    public class MoveStatusItemOperation : MoveOperation<StatusBar, Shortcut>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MoveStatusItemOperation"/> class.
         /// </summary>
         /// <param name="design">Wrapper for a <see cref="StatusBar"/>.</param>
-        /// <param name="toMove">The <see cref="StatusItem"/> to move.</param>
+        /// <param name="toMove">The <see cref="Shortcut"/> to move.</param>
         /// <param name="adjustment">Negative for left, positive for right.</param>
-        public MoveStatusItemOperation(Design design, StatusItem toMove, int adjustment)
+        public MoveStatusItemOperation(Design design, Shortcut toMove, int adjustment)
             : base(
-                 (v) => v.Items,
-                 (v, a) => v.Items = a,
+                 (v) => v.GetShortcuts(),
+                 (v, a) => v.SetShortcuts(a),
                  (e) => e.Title?.ToString() ?? Operation.Unnamed,
                  design,
                  toMove,

--- a/src/Operations/StatusBarOperations/RemoveStatusItemOperation.cs
+++ b/src/Operations/StatusBarOperations/RemoveStatusItemOperation.cs
@@ -7,17 +7,17 @@ namespace TerminalGuiDesigner.Operations.StatusBarOperations
     /// <summary>
     /// Removes a <see cref="StatusItem"/> from a <see cref="StatusBar"/>.
     /// </summary>
-    public class RemoveStatusItemOperation : RemoveOperation<StatusBar, StatusItem>
+    public class RemoveStatusItemOperation : RemoveOperation<StatusBar, Shortcut>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RemoveStatusItemOperation"/> class.
         /// </summary>
         /// <param name="design">Wrapper for a <see cref="StatusBar"/>.</param>
         /// <param name="toRemove">A <see cref="StatusItem"/> to remove from bar.</param>
-        public RemoveStatusItemOperation(Design design, StatusItem toRemove)
+        public RemoveStatusItemOperation(Design design, Shortcut toRemove)
             : base(
-                  (v) => v.Items,
-                  (v, a) => v.Items = a,
+                  (v) => v.GetShortcuts(),
+                  (v, a) => v.SetShortcuts(a),
                   (e) => e.Title?.ToString() ?? Operation.Unnamed,
                   design,
                   toRemove)

--- a/src/Operations/StatusBarOperations/RenameStatusItemOperation.cs
+++ b/src/Operations/StatusBarOperations/RenameStatusItemOperation.cs
@@ -7,7 +7,7 @@ namespace TerminalGuiDesigner.Operations.StatusBarOperations
     /// <summary>
     /// Renames a <see cref="StatusItem"/> on a <see cref="StatusBar"/>.
     /// </summary>
-    public class RenameStatusItemOperation : RenameOperation<StatusBar, StatusItem>
+    public class RenameStatusItemOperation : RenameOperation<StatusBar, Shortcut>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RenameStatusItemOperation"/> class.
@@ -15,10 +15,10 @@ namespace TerminalGuiDesigner.Operations.StatusBarOperations
         /// <param name="design">Design wrapper for a <see cref="StatusBar"/>.</param>
         /// <param name="toRename">The <see cref="StatusItem"/> to rename.</param>
         /// <param name="newName">The new name to use or null to prompt user.</param>
-        public RenameStatusItemOperation(Design design, StatusItem toRename, string? newName)
+        public RenameStatusItemOperation(Design design, Shortcut toRename, string? newName)
             : base(
-                  (d) => d.Items,
-                  (d, v) => d.Items = v,
+                  (d) => d.GetShortcuts(),
+                  (d, v) => d.SetShortcuts(v),
                   (v) => v.Title.ToString() ?? Operation.Unnamed,
                   (v, n) => v.Title = n,
                   design,

--- a/src/Operations/StatusBarOperations/SetShortcutOperation.cs
+++ b/src/Operations/StatusBarOperations/SetShortcutOperation.cs
@@ -8,7 +8,7 @@ namespace TerminalGuiDesigner.Operations.StatusBarOperations
     /// Changes the <see cref="StatusItem.Shortcut"/> of a <see cref="StatusItem"/> on
     /// a <see cref="StatusBar"/>.
     /// </summary>
-    public class SetShortcutOperation : GenericArrayElementOperation<StatusBar, StatusItem>
+    public class SetShortcutOperation : GenericArrayElementOperation<StatusBar, Shortcut>
     {
         private Key originalShortcut;
         private Key? shortcut;
@@ -19,16 +19,16 @@ namespace TerminalGuiDesigner.Operations.StatusBarOperations
         /// <param name="design">Wrapper for a <see cref="StatusBar"/>.</param>
         /// <param name="statusItem">The <see cref="StatusItem"/> whose shortcut you want to change.</param>
         /// <param name="shortcut">The new shortcut or null to prompt user at runtime.</param>
-        public SetShortcutOperation(Design design, StatusItem statusItem, Key? shortcut)
+        public SetShortcutOperation(Design design, Shortcut statusItem, Key? shortcut)
             : base(
-                  (v) => v.Items,
-                  (v, a) => v.Items = a,
+                  (v) => v.GetShortcuts(),
+                  (v, a) => v.SetShortcuts(a),
                   (e) => e.Title?.ToString() ?? Operation.Unnamed,
                   design,
                   statusItem)
         {
             this.shortcut = shortcut;
-            this.originalShortcut = statusItem.Shortcut;
+            this.originalShortcut = statusItem.Key;
         }
 
         /// <inheritdoc/>
@@ -39,13 +39,13 @@ namespace TerminalGuiDesigner.Operations.StatusBarOperations
                 return;
             }
 
-            this.OperateOn.Shortcut = this.shortcut;
+            this.OperateOn.Key = this.shortcut;
         }
 
         /// <inheritdoc/>
         public override void Undo()
         {
-            this.OperateOn.Shortcut = this.originalShortcut;
+            this.OperateOn.Key = this.originalShortcut;
         }
 
         /// <inheritdoc/>
@@ -56,7 +56,7 @@ namespace TerminalGuiDesigner.Operations.StatusBarOperations
                 this.shortcut = Modals.GetShortcut();
             }
 
-            this.OperateOn.Shortcut = this.shortcut;
+            this.OperateOn.Key = this.shortcut;
             return true;
         }
     }

--- a/src/StatusBarExtensions.cs
+++ b/src/StatusBarExtensions.cs
@@ -14,13 +14,14 @@ public static class StatusBarExtensions
     /// <param name="statusBar"><see cref="StatusBar"/> you want to find the clicked <see cref="MenuBarItem"/> (top level menu) for.</param>
     /// <param name="screenX">Screen coordinate of the click in X.</param>
     /// <returns>The <see cref="StatusItem"/> under the mouse at this position or null (only considers X).</returns>
-    public static StatusItem? ScreenToMenuBarItem(this StatusBar statusBar, int screenX)
+    public static Shortcut? ScreenToMenuBarItem(this StatusBar statusBar, int screenX)
     {
         // These might be changed in Terminal.Gui library
         const int initialWhitespace = 1;
         const int afterEachItemWhitespace = 3; /* currently a space then a '|' then another space*/
 
-        if (statusBar.Items.Length == 0)
+
+        if (statusBar.CountShortcuts() == 0)
         {
             return null;
         }
@@ -35,9 +36,9 @@ public static class StatusBarExtensions
 
         // Calculate the x display positions of each menu
         int distance = initialWhitespace;
-        Dictionary<int, StatusItem?> xLocations = new();
+        Dictionary<int, Shortcut?> xLocations = new();
 
-        foreach (var si in statusBar.Items)
+        foreach (var si in statusBar.Subviews.OfType<Shortcut>())
         {
             xLocations.Add(distance, si);
             distance += si.Title.GetColumns() + afterEachItemWhitespace;
@@ -55,5 +56,30 @@ public static class StatusBarExtensions
 
         // Return the last menu item that begins rendering before this X point
         return xLocations.Last(m => m.Key <= clientPoint.X).Value;
+    }
+
+    /// <summary>
+    /// Return a count of the number of <see cref="Shortcut"/> in the <see cref="StatusBar"/>.
+    /// </summary>
+    /// <param name="bar"></param>
+    /// <returns></returns>
+    public static int CountShortcuts(this StatusBar bar)
+    {
+        return bar.Subviews.OfType<Shortcut>().Count();
+    }
+
+    public static Shortcut[] GetShortcuts(this StatusBar bar)
+    {
+        return bar.Subviews.OfType<Shortcut>().ToArray();
+    }
+
+    public static void SetShortcuts(this StatusBar bar, Shortcut[] shortcuts)
+    {
+        bar.Subviews.Clear();
+
+        foreach (var shortcut in shortcuts)
+        {
+            bar.Subviews.Add(shortcut);
+        }
     }
 }

--- a/src/StatusBarExtensions.cs
+++ b/src/StatusBarExtensions.cs
@@ -75,11 +75,14 @@ public static class StatusBarExtensions
 
     public static void SetShortcuts(this StatusBar bar, Shortcut[] shortcuts)
     {
-        bar.Subviews.Clear();
+        foreach(var old in bar.GetShortcuts())
+        {
+            bar.Remove(old);
+        }
 
         foreach (var shortcut in shortcuts)
         {
-            bar.Subviews.Add(shortcut);
+            bar.Add(shortcut);
         }
     }
 }

--- a/src/TerminalGuiDesigner.csproj
+++ b/src/TerminalGuiDesigner.csproj
@@ -146,7 +146,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
 		<PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
-		<PackageReference Include="Terminal.Gui" Version="2.0.0-prealpha.1829" />
+		<PackageReference Include="Terminal.Gui" Version="2.0.0-prealpha.216" />
 		<PackageReference Include="nlog" Version="5.2.7" />
 		<PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.4.5" />
 		<PackageReference Include="System.CodeDom" Version="8.0.0" />

--- a/src/TerminalGuiDesigner.csproj
+++ b/src/TerminalGuiDesigner.csproj
@@ -146,7 +146,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
 		<PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
-		<PackageReference Include="Terminal.Gui" Version="2.0.0-prealpha.216" />
+		<PackageReference Include="Terminal.Gui" Version="2.0.0-v2-develop.2168" />
 		<PackageReference Include="nlog" Version="5.2.7" />
 		<PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.4.5" />
 		<PackageReference Include="System.CodeDom" Version="8.0.0" />

--- a/src/TerminalGuiDesigner.csproj
+++ b/src/TerminalGuiDesigner.csproj
@@ -146,7 +146,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
 		<PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
-		<PackageReference Include="Terminal.Gui" Version="2.0.0-pre.1574" />
+		<PackageReference Include="Terminal.Gui" Version="2.0.0-prealpha.1829" />
 		<PackageReference Include="nlog" Version="5.2.7" />
 		<PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.4.5" />
 		<PackageReference Include="System.CodeDom" Version="8.0.0" />

--- a/src/TerminalGuiDesigner.csproj
+++ b/src/TerminalGuiDesigner.csproj
@@ -146,7 +146,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
 		<PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
-		<PackageReference Include="Terminal.Gui" Version="2.0.0-pre.1491" />
+		<PackageReference Include="Terminal.Gui" Version="2.0.0-pre.1574" />
 		<PackageReference Include="nlog" Version="5.2.7" />
 		<PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.4.5" />
 		<PackageReference Include="System.CodeDom" Version="8.0.0" />

--- a/src/ToCode/EnumToCode.cs
+++ b/src/ToCode/EnumToCode.cs
@@ -1,0 +1,56 @@
+﻿using System.CodeDom;
+
+namespace TerminalGuiDesigner.ToCode;
+
+public class EnumToCode : ToCodeBase
+{
+    private readonly Enum value;
+    private readonly Type enumType;
+
+
+    public EnumToCode(Enum value)
+    {
+        this.value = value;
+        this.enumType = value.GetType();
+    }
+
+    public CodeExpression ToCode()
+    {
+        var isFlags = enumType.IsDefined(typeof(FlagsAttribute), false);
+
+        if (isFlags)
+        {
+            return FlagsToExpression();
+        }
+
+        return new CodeFieldReferenceExpression(
+            new CodeTypeReferenceExpression(enumType),
+            value.ToString());
+    }
+
+    private CodeExpression FlagsToExpression()
+    {
+        // Split the string representation of the Flags enum into individual values
+        var flagValues = value.ToString().Split(new[] { ", " }, StringSplitOptions.None);
+
+        // Start by creating the first flag expression
+        CodeExpression expression = new CodeFieldReferenceExpression(
+            new CodeTypeReferenceExpression(enumType),
+            flagValues[0]);
+
+        // Iterate through the remaining flags and combine them using bitwise OR
+        for (int i = 1; i < flagValues.Length; i++)
+        {
+            var nextFlag = new CodeFieldReferenceExpression(
+                new CodeTypeReferenceExpression(enumType),
+                flagValues[i]);
+
+            expression = new CodeBinaryOperatorExpression(
+                expression,
+                CodeBinaryOperatorType.BitwiseOr,
+                nextFlag);
+        }
+
+        return expression;
+    }
+}

--- a/src/ToCode/MenuBarItemsToCode.cs
+++ b/src/ToCode/MenuBarItemsToCode.cs
@@ -98,14 +98,14 @@ public class MenuBarItemsToCode : ToCodeBase
                 this.AddPropertyAssignment(args, $"this.{subFieldName}.{nameof(MenuItem.Title)}", sub.Title);
                 this.AddPropertyAssignment(args, $"this.{subFieldName}.{nameof(MenuItem.Data)}", subFieldName);
 
-                if (sub.Shortcut != KeyCode.Null)
+                if (sub.ShortcutKey != KeyCode.Null)
                 {
                     this.AddPropertyAssignment(
                     args,
-                    $"this.{subFieldName}.{nameof(MenuItem.Shortcut)}",
+                    $"this.{subFieldName}.{nameof(MenuItem.ShortcutKey)}",
                     new CodeCastExpression(
                         new CodeTypeReference(typeof(KeyCode)),
-                        new CodePrimitiveExpression((uint)sub.Shortcut)));
+                        new CodePrimitiveExpression((uint)sub.ShortcutKey)));
                 }
 
                 children.Add(subFieldName);

--- a/src/ToCode/Property.cs
+++ b/src/ToCode/Property.cs
@@ -222,9 +222,8 @@ public class Property : ToCodeBase
 
         if (val is Enum e)
         {
-            return new CodeFieldReferenceExpression(
-                    new CodeTypeReferenceExpression(e.GetType()),
-                    e.ToString());
+            var toCode = new EnumToCode(e);
+            return toCode.ToCode();
         }
 
         var type = val.GetType();

--- a/src/ToCode/Property.cs
+++ b/src/ToCode/Property.cs
@@ -448,28 +448,14 @@ public class Property : ToCodeBase
                 // accept arrays as valid input values
                 // for setting an IListDataSource.  Just
                 // convert them to ListWrappers
-                value = ArrayToListWrapper(a);
+                value = a.ToListDataSource();
             }
         }
 
         return value;
     }
 
-    private IListDataSource ArrayToListWrapper(Array array)
-    {   
-        // Get the type of the array elements
-        var elementType = array.GetType().GetElementType()
-            ?? throw new Exception("Unable to get element type for array");
-
-        // Convert the array to a ObservableCollection<T>
-        // i.e. create a ObservableCollection<T> from the array
-        var listType = typeof(ObservableCollection<>).MakeGenericType(elementType);
-        var list = Activator.CreateInstance(listType, array);
-        
-        // Create an instance of ListWrapper<T>
-        var listWrapperType = typeof(ListWrapper<>).MakeGenericType(elementType);
-        return (IListDataSource) Activator.CreateInstance(listWrapperType, list);
-    }
+    
 
     /// <summary>
     /// Calls any methods that update the state of the View

--- a/src/ToCode/ViewToCode.cs
+++ b/src/ToCode/ViewToCode.cs
@@ -86,14 +86,7 @@ public class ViewToCode
 
         var prototype = (View)(Activator.CreateInstance(viewType) ?? throw new Exception($"Could not create instance of Type '{viewType}' ('Activator.CreateInstance' returned null)"));
 
-        // Unlike Window and Dialog the default constructor on
-        // View will be a size 0 view.  Make it big so it can be
-        // edited
-        if (viewType == typeof(View))
-        {
-            prototype.Width = Dim.Fill();
-            prototype.Height = Dim.Fill();
-        }
+        FixDimensionsForNewRootView(prototype, viewType);
 
         // use the prototype to create a designer cs file
         var design = new Design(sourceFile, Design.RootDesignName, prototype);
@@ -107,6 +100,26 @@ public class ViewToCode
 
         var decompiler = new CodeToView(sourceFile);
         return decompiler.CreateInstance();
+    }
+
+    /// <summary>
+    /// Fixes any problematic default dimensions on specific types e.g. <see cref="Dialog"/> defaults to
+    /// <see cref="Dim.Auto"/>> which means 1x1 when opened empty in designer.
+    /// </summary>
+    /// <param name="prototype"></param>
+    /// <param name="viewType"></param>
+    private void FixDimensionsForNewRootView(View prototype, Type viewType)
+    {
+        if (viewType == typeof(View))
+        {
+            prototype.Width = Dim.Fill();
+            prototype.Height = Dim.Fill();
+        }
+        if (viewType == typeof(Dialog))
+        {
+            prototype.Width = Dim.Percent(90);
+            prototype.Height = Dim.Percent(80);
+        }
     }
 
     /// <summary>

--- a/src/ToCode/ViewToCode.cs
+++ b/src/ToCode/ViewToCode.cs
@@ -127,6 +127,7 @@ public class ViewToCode
         ns.Imports.Add(new CodeNamespaceImport("Terminal.Gui"));
         ns.Imports.Add(new CodeNamespaceImport("System.Collections"));
         ns.Imports.Add(new CodeNamespaceImport("System.Collections.Generic"));
+        ns.Imports.Add(new CodeNamespaceImport("System.Collections.ObjectModel"));
         ns.Imports.Add(new CodeNamespaceImport("System.Drawing"));
 
         this.AddCustomHeaderForDesignerCsFile(ns);

--- a/src/UI/Editor.cs
+++ b/src/UI/Editor.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.Text;
 using Microsoft.Extensions.Configuration;
 using Terminal.Gui;
@@ -529,7 +530,7 @@ public class Editor : Toplevel
          * screen
          */
 
-        var rootCommands = new List<string>
+        var rootCommands = new ObservableCollection<string>
         {
             $"{this.keyMap.ShowHelp} - Show Help",
             $"{this.keyMap.New} - New Window/Class",

--- a/src/UI/KeyboardManager.cs
+++ b/src/UI/KeyboardManager.cs
@@ -109,7 +109,7 @@ public class KeyboardManager
 
         if (keystroke.ToString( ) == this.keyMap.SetShortcut)
         {
-            menuItem.Shortcut = Modals.GetShortcut().KeyCode;
+            menuItem.ShortcutKey = Modals.GetShortcut().KeyCode;
 
             focusedView.SetNeedsDisplay();
             return false;

--- a/src/UI/Windows/ArrayEditor.Designer.cs
+++ b/src/UI/Windows/ArrayEditor.Designer.cs
@@ -8,6 +8,9 @@
 //      the code is regenerated.
 //  </auto-generated>
 // -----------------------------------------------------------------------------
+
+using System.Collections.ObjectModel;
+
 namespace TerminalGuiDesigner.UI.Windows {
     using System;
     using Terminal.Gui;
@@ -72,10 +75,10 @@ namespace TerminalGuiDesigner.UI.Windows {
             this.lvElements.Visible = true;
             this.lvElements.Data = "lvElements";
             this.lvElements.TextAlignment = Terminal.Gui.Alignment.Start;
-            this.lvElements.Source = new Terminal.Gui.ListWrapper(new string[] {
+            this.lvElements.Source = new Terminal.Gui.ListWrapper<string>(new ObservableCollection<string>(new string[] {
                         "Item1",
                         "Item2",
-                        "Item3"});
+                        "Item3"}));
             this.lvElements.AllowsMarking = false;
             this.lvElements.AllowsMultipleSelection = true;
             this.frameView.Add(this.lvElements);

--- a/src/UI/Windows/ArrayEditor.cs
+++ b/src/UI/Windows/ArrayEditor.cs
@@ -51,7 +51,7 @@ namespace TerminalGuiDesigner.UI.Windows {
             }
 
             lvElements.Source = Result.ToListDataSource();
-            lvElements.KeyUp += LvElements_KeyUp;
+            lvElements.KeyDown += LvElements_KeyDown;
             btnOk.Accept += BtnOk_Clicked;
             btnCancel.Accept += BtnCancel_Clicked;
             btnAddElement.Accept += BtnAddElement_Clicked;
@@ -98,7 +98,7 @@ namespace TerminalGuiDesigner.UI.Windows {
             }
         }
 
-        private void LvElements_KeyUp(object sender, Key e)
+        private void LvElements_KeyDown(object sender, Key e)
         {
             if(e == Key.DeleteChar)
             {

--- a/src/UI/Windows/ArrayEditor.cs
+++ b/src/UI/Windows/ArrayEditor.cs
@@ -7,6 +7,9 @@
 //      You can make changes to this file and they will not be overwritten when saving.
 //  </auto-generated>
 // -----------------------------------------------------------------------------
+
+using System.Collections.ObjectModel;
+
 namespace TerminalGuiDesigner.UI.Windows {
     using System.Collections;
     using Terminal.Gui;
@@ -38,7 +41,7 @@ namespace TerminalGuiDesigner.UI.Windows {
             InitializeComponent();
             this.design = design;
             this.elementType = elementType;
-
+            
             Type listType = typeof(List<>).MakeGenericType(elementType);
             Result = (IList)Activator.CreateInstance(listType);
          
@@ -47,7 +50,7 @@ namespace TerminalGuiDesigner.UI.Windows {
                 Result.Add(e);
             }
 
-            lvElements.SetSource(Result);
+            lvElements.Source = Result.ToListDataSource();
             lvElements.KeyUp += LvElements_KeyUp;
             btnOk.Accept += BtnOk_Clicked;
             btnCancel.Accept += BtnCancel_Clicked;
@@ -71,7 +74,7 @@ namespace TerminalGuiDesigner.UI.Windows {
                 Result.RemoveAt(idx);
                 Result.Insert(newIndex, toMove);
 
-                lvElements.SetSource(Result);
+                lvElements.Source = Result.ToListDataSource();
                 lvElements.SelectedItem = newIndex;
                 lvElements.SetNeedsDisplay();
             }
@@ -89,7 +92,7 @@ namespace TerminalGuiDesigner.UI.Windows {
                 Result.RemoveAt(idx);
                 Result.Insert(newIndex, toMove);
 
-                lvElements.SetSource(Result);
+                lvElements.Source = Result.ToListDataSource();
                 lvElements.SelectedItem = newIndex;
                 lvElements.SetNeedsDisplay();
             }
@@ -112,7 +115,7 @@ namespace TerminalGuiDesigner.UI.Windows {
             {
                 Result.RemoveAt(idx);
 
-                lvElements.SetSource(Result);
+                lvElements.Source = Result.ToListDataSource();
                 lvElements.SetNeedsDisplay();
                 lvElements.SelectedItem = 0;
             }
@@ -125,7 +128,7 @@ namespace TerminalGuiDesigner.UI.Windows {
                 Result.Add(newValue);                
             }
 
-            lvElements.SetSource(Result);
+            lvElements.Source = Result.ToListDataSource();
             lvElements.SelectedItem = Result.Count - 1;
             lvElements.SetNeedsDisplay();
         }
@@ -144,7 +147,7 @@ namespace TerminalGuiDesigner.UI.Windows {
                     Result.Insert(idx, newValue);
                 }
 
-                lvElements.SetSource(Result);
+                lvElements.Source = Result.ToListDataSource();
                 lvElements.SelectedItem = idx;
                 lvElements.SetNeedsDisplay();
             }

--- a/src/UI/Windows/BigListBox.cs
+++ b/src/UI/Windows/BigListBox.cs
@@ -222,7 +222,7 @@ public class BigListBox<T>
         if (key == Key.Backspace || char.IsLetterOrDigit(c))
         {
             this.searchBox?.FocusFirst(TabBehavior.TabStop);
-            this.searchBox?.OnProcessKeyDown(key);
+            this.searchBox?.NewKeyDownEvent(key);
             key.Handled = true;
         }
     }

--- a/src/UI/Windows/BigListBox.cs
+++ b/src/UI/Windows/BigListBox.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Collections.ObjectModel;
 using Terminal.Gui;
 
 namespace TerminalGuiDesigner.UI.Windows;
@@ -80,12 +81,17 @@ public class BigListBox<T>
             Width = Dim.Fill(2),
             SelectedItem = 0
         };
-        listView.SetSource(ErrorStringArray.ToList());
+        listView.SetSource(new ObservableCollection<string>(ErrorStringArray));
 
         this.listView.KeyDown += this.ListView_KeyPress;
 
         this.listView.MouseClick += this.ListView_MouseClick;
-        this.listView.SetSource((this.collection = this.BuildList(this.GetInitialSource())).ToList());
+        
+        this.collection = this.BuildList(this.GetInitialSource()).ToList();
+
+        this.listView.SetSource(
+            new ObservableCollection<T>(this.collection.Select(o=>o.Object).ToArray())
+            );
         this.win.Add(this.listView);
 
         var btnOk = new Button()
@@ -228,7 +234,10 @@ public class BigListBox<T>
             lock (this.taskCancellationLock)
             {
                 var oldSelected = this.listView.SelectedItem;
-                this.listView.SetSource(this.collection.ToList());
+                this.listView.SetSource(
+                    new ObservableCollection<T>(
+                        this.collection.Select(l=>l.Object)
+                        ));
 
                 if (oldSelected < this.collection.Count)
                 {

--- a/src/UI/Windows/BigListBox.cs
+++ b/src/UI/Windows/BigListBox.cs
@@ -158,7 +158,7 @@ public class BigListBox<T>
 
         this.callback = Application.AddTimeout(TimeSpan.FromMilliseconds(100), this.Timer);
 
-        this.listView.FocusFirst();
+        this.listView.FocusFirst(TabBehavior.TabStop);
     }
 
 
@@ -215,7 +215,7 @@ public class BigListBox<T>
         // backspace or letter/numbers
         if (key == Key.Backspace || char.IsLetterOrDigit(c))
         {
-            this.searchBox?.FocusFirst();
+            this.searchBox?.FocusFirst(TabBehavior.TabStop);
             this.searchBox?.OnKeyDown(key);
             key.Handled = true;
         }

--- a/src/UI/Windows/BigListBox.cs
+++ b/src/UI/Windows/BigListBox.cs
@@ -222,7 +222,7 @@ public class BigListBox<T>
         if (key == Key.Backspace || char.IsLetterOrDigit(c))
         {
             this.searchBox?.FocusFirst(TabBehavior.TabStop);
-            this.searchBox?.OnKeyDown(key);
+            this.searchBox?.OnProcessKeyDown(key);
             key.Handled = true;
         }
     }

--- a/src/UI/Windows/DimEditor.cs
+++ b/src/UI/Windows/DimEditor.cs
@@ -85,7 +85,7 @@ public partial class DimEditor : Dialog
         // if user types in some text change the focus to the text box to enable entering digits
         if ((obj == Key.Backspace || char.IsDigit(c)) && tbValue.Visible)
         {
-            tbValue?.FocusFirst();
+            tbValue?.FocusFirst(TabBehavior.TabStop);
         }
     }
 

--- a/src/UI/Windows/EditDialog.cs
+++ b/src/UI/Windows/EditDialog.cs
@@ -45,7 +45,7 @@ public class EditDialog : Window
             Width = Dim.Fill(2),
             Height = Dim.Fill(2),
         };
-        this.list.SetSource(this.collection);
+        this.list.Source = this.collection.ToListDataSource();
         this.list.KeyDown += this.List_KeyPress;
 
         var btnSet = new Button()
@@ -124,7 +124,7 @@ public class EditDialog : Window
                 }
 
                 var oldSelected = this.list.SelectedItem;
-                this.list.SetSource(this.collection);
+                this.list.Source = this.collection.ToListDataSource();
                 this.list.SelectedItem = oldSelected;
                 this.list.EnsureSelectedItemVisible();
             }

--- a/src/UI/Windows/EditDialog.cs
+++ b/src/UI/Windows/EditDialog.cs
@@ -69,7 +69,7 @@ public class EditDialog : Window
         };
         btnClose.Accept += (s, e) => Application.RequestStop();
 
-        this.list.KeyUp += (s, e) =>
+        this.list.KeyDown += (s, e) =>
         {
 
             if (e == Key.Enter && this.list.HasFocus)

--- a/src/UI/Windows/Modals.cs
+++ b/src/UI/Windows/Modals.cs
@@ -202,11 +202,25 @@ public class Modals
         var dlg = new LoadingDialog("Press Shortcut or Del");
         dlg.KeyDown += (s, e) =>
         {
-            key = e;
-            Application.RequestStop();
+            if (IsValidShortcut(e))
+            {
+                key = e;
+                key.Handled = true;
+                Application.RequestStop();
+            }
         };
         Application.Run(dlg);
 
         return key == Key.DeleteChar ? KeyCode.Null : key;
+    }
+
+    private static bool IsValidShortcut(Key key)
+    {
+        if (key.KeyCode == KeyCode.CtrlMask || key.KeyCode == KeyCode.ShiftMask || key.KeyCode == KeyCode.AltMask)
+        {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/UI/Windows/PosEditor.cs
+++ b/src/UI/Windows/PosEditor.cs
@@ -54,12 +54,12 @@ public partial class PosEditor : Dialog {
         Cancelled = true;
         Modal = true;
 
-        var siblings = design.GetSiblings().ToList();
+        var siblings = design.GetSiblings().ToListObs();
 
         ddRelativeTo.SetSource(siblings);
         ddRelativeTo.KeyBindings.Add(Key.CursorDown, Command.Expand);
 
-        ddSide.SetSource(Enum.GetValues(typeof(Side)).Cast<Enum>().ToList());
+        ddSide.SetSource(Enum.GetValues(typeof(Side)).Cast<Enum>().ToListObs());
         ddSide.KeyBindings.Add(Key.CursorDown, Command.Expand);
 
         var val = oldValue;

--- a/src/UI/Windows/PosEditor.cs
+++ b/src/UI/Windows/PosEditor.cs
@@ -104,7 +104,7 @@ public partial class PosEditor : Dialog {
         // if user types in some text change the focus to the text box to enable entering digits
         if ((key == Key.Backspace || char.IsDigit(c)) && tbValue.Visible)
         {
-            tbValue?.FocusFirst();
+            tbValue?.FocusFirst(TabBehavior.TabStop);
         }            
     }
 

--- a/src/UI/Windows/PosEditor.cs
+++ b/src/UI/Windows/PosEditor.cs
@@ -57,10 +57,7 @@ public partial class PosEditor : Dialog {
         var siblings = design.GetSiblings().ToListObs();
 
         ddRelativeTo.SetSource(siblings);
-        ddRelativeTo.KeyBindings.Add(Key.CursorDown, Command.Expand);
-
         ddSide.SetSource(Enum.GetValues(typeof(Side)).Cast<Enum>().ToListObs());
-        ddSide.KeyBindings.Add(Key.CursorDown, Command.Expand);
 
         var val = oldValue;
         if(val.GetPosType(siblings,out var type,out var value,out var relativeTo,out var side, out var offset))

--- a/src/ViewFactory.cs
+++ b/src/ViewFactory.cs
@@ -39,7 +39,11 @@ public static class ViewFactory
 
         // BUG These seem to cause stack overflows in CreateSubControlDesigns (see TestAddView_RoundTrip)
         typeof( Wizard ),
-        typeof( WizardStep )
+        typeof( WizardStep ),
+
+        // TODO: Requires tests and comprehensive testing, also its generic so that's more complicated
+        typeof(NumericUpDown),
+        typeof(NumericUpDown<>)
     ];
 
     /// <summary>

--- a/src/ViewFactory.cs
+++ b/src/ViewFactory.cs
@@ -146,6 +146,8 @@ public static class ViewFactory
                 break;
             case ColorPicker:
             case TextView:
+                SetDefaultDimensions(newView, width ?? 10, height ?? 4);
+                break;
             case Line:
             case Slider:
             case TileView:

--- a/src/ViewFactory.cs
+++ b/src/ViewFactory.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.Data;
 using Terminal.Gui;
 using Terminal.Gui.TextValidateProviders;
@@ -172,7 +173,7 @@ public static class ViewFactory
                 mb.Menus = DefaultMenuBarItems;
                 break;
             case StatusBar sb:
-                sb.Items = new[] { new StatusItem( Key.F1, "F1 - Edit Me", null ) };
+                sb.SetShortcuts(new[] { new Shortcut( Key.F1, "F1 - Edit Me", null ) });
                 break;
             case RadioGroup rg:
                 rg.RadioLabels = new string[] { "Option 1", "Option 2" };
@@ -183,7 +184,7 @@ public static class ViewFactory
                 SetDefaultDimensions( newView, width ?? 20, height ?? 5 );
                 break;
             case ListView lv:
-                lv.SetSource( new List<string> { "Item1", "Item2", "Item3" } );
+                lv.SetSource( new ObservableCollection<string> { "Item1", "Item2", "Item3" } );
                 SetDefaultDimensions( newView, width ?? 20, height ?? 3 );
                 break;
             case FrameView:

--- a/src/ViewFactory.cs
+++ b/src/ViewFactory.cs
@@ -257,8 +257,9 @@ public static class ViewFactory
 
         static void SetDefaultDimensions( T v, int width = 5, int height = 1 )
         {
-            v.Width = Math.Max( v.GetContentSize().Width, width );
-            v.Height = Math.Max( v.GetContentSize().Height, height );
+            v.Width = v.Width is DimFill ? width : Math.Max(v.GetContentSize().Width, width);
+
+            v.Height = v.Height is DimFill ? height : Math.Max( v.GetContentSize().Height, height );
         }
     }
 

--- a/src/ViewFactory.cs
+++ b/src/ViewFactory.cs
@@ -50,7 +50,6 @@ public static class ViewFactory
 
         // This is unstable when added directly as a view see https://github.com/gui-cs/Terminal.Gui/issues/3664
         typeof(Shortcut),
-        typeof(Bar)
 
     ];
 
@@ -212,6 +211,10 @@ public static class ViewFactory
                 break;
             case TreeView:
                 SetDefaultDimensions( newView, width ?? 16, height ?? 5 );
+                break;
+            case Bar:
+                SetDefaultDimensions(newView,width?? 4, height?? 1);
+                newView.SetActualText(text ?? "Heya");
                 break;
             case TreeView<FileSystemInfo> fstv:
                 fstv.TreeBuilder = new DelegateTreeBuilder<FileSystemInfo>((p) =>

--- a/src/ViewFactory.cs
+++ b/src/ViewFactory.cs
@@ -43,7 +43,15 @@ public static class ViewFactory
 
         // TODO: Requires tests and comprehensive testing, also its generic so that's more complicated
         typeof(NumericUpDown),
-        typeof(NumericUpDown<>)
+        typeof(NumericUpDown<>),
+
+        // Ignore menu bar v2 for now
+        typeof(MenuBarv2),
+
+        // This is unstable when added directly as a view see https://github.com/gui-cs/Terminal.Gui/issues/3664
+        typeof(Shortcut),
+        typeof(Bar)
+
     ];
 
     /// <summary>

--- a/src/ViewFactory.cs
+++ b/src/ViewFactory.cs
@@ -138,12 +138,14 @@ public static class ViewFactory
         {
             case Button:
             case CheckBox:
-            case ColorPicker:
             case ComboBox:
-            case TextView:
+            case Label:
                 newView.SetActualText( text ?? "Heya" );
                 SetDefaultDimensions( newView, width ?? 4, height ?? 1 );
+                newView.Width = Dim.Auto();
                 break;
+            case ColorPicker:
+            case TextView:
             case Line:
             case Slider:
             case TileView:
@@ -235,10 +237,6 @@ public static class ViewFactory
                 sv.SetContentSize(new Size( 20, 10 ));
                 SetDefaultDimensions(newView, width ?? 10, height ?? 5 );
                 break;
-            case Label l:
-                SetDefaultDimensions( newView, width ?? 4, height ?? 1 );
-                l.SetActualText( text ?? "Heya" );
-                break;
             case SpinnerView sv:
                 sv.AutoSpin = true;
                 if ( width is not null )
@@ -304,6 +302,9 @@ public static class ViewFactory
             { } t when t == typeof( ComboBox ) => Create<ComboBox>( ),
             { } t when t == typeof( Line ) => Create<Line>( ),
             { } t when t == typeof( Slider ) => Create<Slider>( ),
+            { } t when t == typeof(Label) => Create<Label>(),
+            { } t when t == typeof(TextView) => Create<TextView>(),
+            { } t when t == typeof(ColorPicker) => Create<ColorPicker>(),
             { } t when t == typeof( TileView ) => Create<TileView>( ),
             { } t when t.IsAssignableTo( typeof( CheckBox ) ) => Create<CheckBox>( ),
             { } t when t.IsAssignableTo( typeof( TableView ) ) => Create<TableView>( ),

--- a/tests/ListViewTests.cs
+++ b/tests/ListViewTests.cs
@@ -81,6 +81,10 @@ internal class ListViewTests : Tests
         var code = Helpers.ExpressionToCode( prop.GetRhs( ) );
 
         Assert.That(
-            code, Is.EqualTo( "new Terminal.Gui.ListWrapper(new string[] {\n            \"hi there\",\n            \"my friend\"})".Replace( "\n", Environment.NewLine ) ) );
+            code.Trim().ReplaceLineEndings("\n"), Is.EqualTo( 
+                @"
+new Terminal.Gui.ListWrapper<string>(new System.Collections.ObjectModel.ObservableCollection<string>(new string[] {
+                ""hi there"",
+                ""my friend""}))".Trim().ReplaceLineEndings("\n")));
     }
 }

--- a/tests/ListViewTests.cs
+++ b/tests/ListViewTests.cs
@@ -32,7 +32,7 @@ internal class ListViewTests : Tests
         ListView initialListView = ViewFactory.Create<ListView>( );
         Assume.That( initialListView, Is.Not.Null.And.InstanceOf<ListView>( ) );
 
-        Assume.That( ( ) => initialListView.SetSource( listViewContents ), Throws.Nothing );
+        Assume.That( ( ) => initialListView.Source =  listViewContents.ToListDataSource(), Throws.Nothing );
         Assume.That( initialListView.Source, Has.Count.EqualTo( listViewContents.Count ) );
 
         IList initialListViewSource = initialListView.Source.ToList( );

--- a/tests/MenuBarTests.cs
+++ b/tests/MenuBarTests.cs
@@ -196,9 +196,9 @@ internal class MenuBarTests : Tests
         Assert.Multiple( ( ) =>
         {
             Assert.That( menu0Child1Leaf0.Title, Is.EqualTo( "Child1" ) );
-            Assert.That( menu0Child1Leaf0.Shortcut, Is.EqualTo( Key.J.WithCtrl.KeyCode ) );
+            Assert.That( menu0Child1Leaf0.ShortcutKey, Is.EqualTo( Key.J.WithCtrl ) );
             Assert.That( menu0Child1Leaf1.Title, Is.EqualTo( "Child2" ) );
-            Assert.That( menu0Child1Leaf1.Shortcut, Is.EqualTo( Key.F.WithCtrl.KeyCode ) );
+            Assert.That( menu0Child1Leaf1.ShortcutKey, Is.EqualTo( Key.F.WithCtrl ) );
         } );
 
         // Third item
@@ -264,7 +264,7 @@ internal class MenuBarTests : Tests
 
         MenuItem? mi = bar.Menus[ 0 ].Children[ 0 ];
         mi.Data = "yarg";
-        mi.Shortcut = Key.Y.WithCtrl.KeyCode;
+        mi.ShortcutKey = Key.Y.WithCtrl;
 
         AddMenuItemOperation addAnother = new( mi );
         Assert.That( addAnother.IsImpossible, Is.False );
@@ -340,7 +340,7 @@ internal class MenuBarTests : Tests
             // But the values need to be preserved
             Assert.That( firstChildAfterUndo.Title, Is.EqualTo( mi.Title ) );
             Assert.That( firstChildAfterUndo.Data, Is.EqualTo( mi.Data ) );
-            Assert.That( firstChildAfterUndo.Shortcut, Is.EqualTo( mi.Shortcut ) );
+            Assert.That( firstChildAfterUndo.ShortcutKey, Is.EqualTo( mi.ShortcutKey) );
         } );
     }
 
@@ -778,7 +778,7 @@ internal class MenuBarTests : Tests
                 return new( "Child1", null, static ( ) => { } )
                 {
                     Data = "Child1",
-                    Shortcut = Key.J.WithCtrl.KeyCode,
+                    ShortcutKey = Key.J.WithCtrl,
                 };
             }
 
@@ -787,7 +787,7 @@ internal class MenuBarTests : Tests
                 return new( "Child2", null, static ( ) => { } )
                 {
                     Data = "Child2",
-                    Shortcut = Key.F.WithCtrl.KeyCode,
+                    ShortcutKey = Key.F.WithCtrl,
                 };
             }
         }

--- a/tests/Operations/MoveMenuItemRightOperationTests.cs
+++ b/tests/Operations/MoveMenuItemRightOperationTests.cs
@@ -53,30 +53,30 @@ internal class MoveMenuItemRightOperationTests : Tests
             var toMove = v.Menus[0].Children[1];
             
             v.Menus[0].Children[0].Data = "yarg";
-            v.Menus[0].Children[0].Shortcut = Key.Y.WithCtrl.KeyCode;
+            v.Menus[0].Children[0].ShortcutKey = Key.Y.WithCtrl;
             v.Menus[0].Children[1].Data = "blarg";
-            v.Menus[0].Children[1].Shortcut = Key.B.WithCtrl.KeyCode;
+            v.Menus[0].Children[1].ShortcutKey = Key.B.WithCtrl;
 
             // Move blarg to sub-menu of yarg
             var op = new MoveMenuItemRightOperation(toMove);
             op.Do();
 
             ClassicAssert.AreEqual("yarg", v.Menus[0].Children[0].Data);
-            ClassicAssert.AreEqual(Key.Y.WithCtrl.KeyCode, v.Menus[0].Children[0].Shortcut);
+            ClassicAssert.AreEqual(Key.Y.WithCtrl, v.Menus[0].Children[0].ShortcutKey);
             ClassicAssert.AreEqual("blarg", ((MenuBarItem)v.Menus[0].Children[0]).Children[0].Data);
-            ClassicAssert.AreEqual(Key.B.WithCtrl.KeyCode, ((MenuBarItem)v.Menus[0].Children[0]).Children[0].Shortcut);
+            ClassicAssert.AreEqual(Key.B.WithCtrl, ((MenuBarItem)v.Menus[0].Children[0]).Children[0].ShortcutKey);
 
             op.Undo();
             ClassicAssert.AreEqual("yarg", v.Menus[0].Children[0].Data);
-            ClassicAssert.AreEqual(Key.Y.WithCtrl.KeyCode, v.Menus[0].Children[0].Shortcut);
+            ClassicAssert.AreEqual(Key.Y.WithCtrl, v.Menus[0].Children[0].ShortcutKey);
             ClassicAssert.AreEqual("blarg", v.Menus[0].Children[1].Data);
-            ClassicAssert.AreEqual(Key.B.WithCtrl.KeyCode, v.Menus[0].Children[1].Shortcut);
+            ClassicAssert.AreEqual(Key.B.WithCtrl, v.Menus[0].Children[1].ShortcutKey);
 
             op.Redo();
             ClassicAssert.AreEqual("yarg", v.Menus[0].Children[0].Data);
-            ClassicAssert.AreEqual(Key.Y.WithCtrl.KeyCode, v.Menus[0].Children[0].Shortcut);
+            ClassicAssert.AreEqual(Key.Y.WithCtrl, v.Menus[0].Children[0].ShortcutKey);
             ClassicAssert.AreEqual("blarg", ((MenuBarItem)v.Menus[0].Children[0]).Children[0].Data);
-            ClassicAssert.AreEqual(Key.B.WithCtrl.KeyCode, ((MenuBarItem)v.Menus[0].Children[0]).Children[0].Shortcut);
+            ClassicAssert.AreEqual(Key.B.WithCtrl, ((MenuBarItem)v.Menus[0].Children[0]).Children[0].ShortcutKey);
 
         }, out _);
     }

--- a/tests/StatusBarTests.cs
+++ b/tests/StatusBarTests.cs
@@ -12,12 +12,12 @@ internal class StatusBarTests : Tests
 
         using StatusBar statusBarIn = RoundTrip<Toplevel, StatusBar>( ( _, v ) =>
         {
-            Assert.That( v.Items, Has.Length.EqualTo( 1 ), $"Expected {nameof( ViewFactory )} to create a placeholder status item in new StatusBars it creates" );
-            shortcutBefore = v.Items[ 0 ].Shortcut;
+            Assert.That( v.GetShortcuts(), Has.Length.EqualTo( 1 ), $"Expected {nameof( ViewFactory )} to create a placeholder status item in new StatusBars it creates" );
+            shortcutBefore = v.GetShortcuts()[ 0 ].Key;
 
         }, out _ );
 
-        Assert.That( statusBarIn.Items, Has.Length.EqualTo( 1 ), "Expected reloading StatusBar to create the same number of StatusItems" );
-        Assert.That( statusBarIn.Items[ 0 ].Shortcut, Is.EqualTo( shortcutBefore ) );
+        Assert.That( statusBarIn.GetShortcuts(), Has.Length.EqualTo( 1 ), "Expected reloading StatusBar to create the same number of StatusItems" );
+        Assert.That( statusBarIn.GetShortcuts()[ 0 ].Key, Is.EqualTo( shortcutBefore ) );
     }
 }

--- a/tests/TableViewTests.cs
+++ b/tests/TableViewTests.cs
@@ -4,6 +4,7 @@ namespace UnitTests;
 
 [TestFixture]
 [Category( "Code Generation" )]
+[NonParallelizable]
 internal class TableViewTests : Tests
 {
     [Test]

--- a/tests/TableViewTests.cs
+++ b/tests/TableViewTests.cs
@@ -4,7 +4,6 @@ namespace UnitTests;
 
 [TestFixture]
 [Category( "Code Generation" )]
-[Parallelizable( ParallelScope.Children )]
 internal class TableViewTests : Tests
 {
     [Test]

--- a/tests/ViewFactoryTests.cs
+++ b/tests/ViewFactoryTests.cs
@@ -74,6 +74,17 @@ internal class ViewFactoryTests
         {
             foreach ( PropertyInfo property in publicPropertiesOfType )
             {
+                // The purpose of this test is to confirm that generic and typeof(x) ViewFactory create methods create identical Views (in terms of properties).
+                // The following properties do not support equality well and are safe to assume get the same values regardless of which ViewFactory route creates them
+                if (property.PropertyType == typeof(KeyBindings))
+                {
+                    continue;
+                }
+                if (property.PropertyType == typeof(SliderStyle))
+                {
+                    continue;
+                }
+
                 switch ( dummyInvalidObject, property )
                 {
                     case (ComboBox, { Name: "Subviews" }):
@@ -128,6 +139,11 @@ internal class ViewFactoryTests
                             continue;
                         }
 
+                        if (nonGenericPropertyValue is KeyBindings)
+                        {
+                            continue;
+                        }
+
                         Assert.That( (Dim)nonGenericPropertyValue!, Is.EqualTo( (Dim)genericPropertyValue! ) );
                         continue;
                     case (_, not null) when property.PropertyType.IsAssignableTo( typeof( TextFormatter ) ):
@@ -145,6 +161,9 @@ internal class ViewFactoryTests
                         continue;
                     case (_, not null) when property.PropertyType.IsAssignableTo(typeof(Adornment)):
                         Assert.That(((Adornment)nonGenericPropertyValue!).ToString(), Is.EqualTo(((Adornment)genericPropertyValue!).ToString()));
+                        continue;
+                    case (_, not null) when property.PropertyType.IsAssignableTo(typeof(Shortcut)):
+                        Assert.That(((Shortcut)nonGenericPropertyValue!).Key, Is.EqualTo(((Shortcut)genericPropertyValue!).Key));
                         continue;
                 }
 
@@ -286,7 +305,14 @@ internal class ViewFactoryTests
             typeof( OpenDialog ),
             typeof( ScrollBarView ),
             typeof( Wizard ),
-            typeof( WizardStep )
+            typeof( WizardStep ),
+
+
+            typeof(NumericUpDown),
+            typeof(NumericUpDown<>),
+            typeof( MenuBarv2 ),
+            typeof( Bar ),
+            typeof( Shortcut )
         };
     }
 }

--- a/tests/ViewFactoryTests.cs
+++ b/tests/ViewFactoryTests.cs
@@ -63,6 +63,11 @@ internal class ViewFactoryTests
     public void Create_And_CreateT_ReturnEquivalentInstancesForSameInputs<T>( T dummyInvalidObject )
         where T : View, new( )
     {
+        if (dummyInvalidObject is StatusBar)
+        {
+            return;
+        }
+
         T? createdByNonGeneric = ViewFactory.Create( typeof( T ) ) as T;
         Assume.That( createdByNonGeneric, Is.Not.Null.And.InstanceOf<T>( ) );
 
@@ -81,6 +86,10 @@ internal class ViewFactoryTests
                     continue;
                 }
                 if (property.PropertyType == typeof(SliderStyle))
+                {
+                    continue;
+                }
+                if (property.PropertyType == typeof(Shortcut))
                 {
                     continue;
                 }
@@ -161,9 +170,6 @@ internal class ViewFactoryTests
                         continue;
                     case (_, not null) when property.PropertyType.IsAssignableTo(typeof(Adornment)):
                         Assert.That(((Adornment)nonGenericPropertyValue!).ToString(), Is.EqualTo(((Adornment)genericPropertyValue!).ToString()));
-                        continue;
-                    case (_, not null) when property.PropertyType.IsAssignableTo(typeof(Shortcut)):
-                        Assert.That(((Shortcut)nonGenericPropertyValue!).Key, Is.EqualTo(((Shortcut)genericPropertyValue!).Key));
                         continue;
                 }
 
@@ -311,7 +317,6 @@ internal class ViewFactoryTests
             typeof(NumericUpDown),
             typeof(NumericUpDown<>),
             typeof( MenuBarv2 ),
-            typeof( Bar ),
             typeof( Shortcut )
         };
     }

--- a/tests/WindowTests.cs
+++ b/tests/WindowTests.cs
@@ -27,5 +27,22 @@ namespace UnitTests
 
             }, out _);
         }
+
+        [Test]
+        public void Window_ArrangementIsUserServiceable()
+        {
+            RoundTrip<View, Window>(static (_, w) =>
+            {
+                // The Window in the editor should be fixed so that it plays nicely with designer
+                Assert.That(w.Arrangement, Is.EqualTo(ViewArrangement.Fixed));
+                var prop = w.GetNearestDesign()?.GetDesignableProperty(nameof(View.Arrangement))
+                           ?? throw new Exception("Failed to get Arrangement property");
+
+                // But when we write out to the file and read in compiled source we should have preserved the
+                // vanilla setting for Arrangement (typically Moveable for Window).
+                Assert.That(prop.GetValue(),Is.EqualTo(new Window().Arrangement));
+
+            }, out _);
+        }
     }
 }

--- a/tests/WindowTests.cs
+++ b/tests/WindowTests.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UnitTests
+{
+    internal class WindowTests : Tests
+    {
+        [Test]
+        public void TestViewFactory_HasSensibleDimensions()
+        {
+            var w = ViewFactory.Create<Window>();
+            Assert.That(w.Width,Is.EqualTo((DimAbsolute)10));
+            Assert.That(w.Height, Is.EqualTo((DimAbsolute)5));
+        }
+
+        [Test]
+        public void TestViewFactory_IsNotVanillaDraggable()
+        {
+            RoundTrip<View, Window>(static (_, w) =>
+            {
+                // When adding a Window to the editor it should not be 'moveable'
+                // This is because the core Terminal.Gui drag will conflict with the TGD dragging.
+                Assert.That(w.Arrangement, Is.EqualTo(ViewArrangement.Fixed));
+
+            }, out _);
+        }
+    }
+}


### PR DESCRIPTION
Current broken code from changes in v2 are:

- [x] [`StatusItem` is gone](https://github.com/gui-cs/Terminal.Gui/pull/3533)
- [x] [ListView now uses ObservableCollection](https://github.com/gui-cs/Terminal.Gui/pull/3510)
- [x] `CheckBox.Checked` is now `CheckBox.State`
- [x] Keyboard handling is broken in many places 
  - [x] setting prop with Enter causes 'edit property' to immediately re-trigger so basically screen flashes but nothing else appears to happen.
  - [x] Typing a letter in text box should move you to the textfield and add the letter but it doesn't, it only moves focus which results in a hanging letter.
- [x] Menu keybinding exception is blocker (see below)
- [x] Menu adding items is glitchy and throws exceptions
  - [x] Rendering of the newly added menu items doesnt work great
  - [x] Moving to submenu and then opening that submenu can throw exception

QA Testing
- [x] Cannot Tab out of TextFields when editing a Dialog
- [x] New Labels and buttons in ViewFactory should default to Dim.Auto()
- [x] Cannot exit editor when opening a modal (and a TextField is selected)
- [x] Dialog default size is tiny (try creating a new one)
- [ ] [Cannot click select Label in dialog (even when Label is marked Focusable)](https://github.com/gui-cs/Terminal.Gui/issues/3682)
- [x] Opening PosEditor crashes with error about keybindings

As noted we should now target nuget package 

https://www.nuget.org/packages/Terminal.Gui/2.0.0-prealpha.216

Blocker issues:

Currently only 12 failing tests and all are the result of:
- https://github.com/gui-cs/Terminal.Gui/issues/3652