### PR TITLE
Update dependency to 2329

### DIFF
--- a/Showcase/Showcase.csproj
+++ b/Showcase/Showcase.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Terminal.Gui" Version="2.0.0-v2-develop.2203" />
+    <PackageReference Include="Terminal.Gui" Version="2.0.0-v2-develop.2329" />
   </ItemGroup>
 
 </Project>

--- a/src/DesignState.cs
+++ b/src/DesignState.cs
@@ -23,7 +23,7 @@ public class DesignState
         this.Design = design;
         this.OriginalScheme = this.Design.View.GetExplicitColorScheme();
         this.Design.View.DrawContentComplete += this.DrawContentComplete;
-        this.Design.View.Enter += this.Enter;
+        this.Design.View.HasFocusChanged += this.FocusChanged;
     }
 
     /// <summary>
@@ -39,8 +39,14 @@ public class DesignState
     /// </summary>
     public Design Design { get; }
 
-    private void Enter(object? sender, FocusEventArgs obj)
+    private void FocusChanged(object? sender, HasFocusEventArgs obj)
     {
+        if (!obj.NewValue)
+        {
+            // not an Enter event so ignore
+            return;
+        }
+
         // when tabbing or clicking into this View when nothing complicated is going on (e.g. Ctrl+Click multi select)
         if (SelectionManager.Instance.Selected.Count <= 1)
         {

--- a/src/TerminalGuiDesigner.csproj
+++ b/src/TerminalGuiDesigner.csproj
@@ -20,7 +20,7 @@
 		<PackageOutputPath>./nupkg</PackageOutputPath>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<PackageId>TerminalGuiDesigner</PackageId>
-		<Version>2.0.0-alpha.2203</Version>
+		<Version>2.0.0-alpha.2239</Version>
 		<Authors>Thomas Nind</Authors>
 		<Nullable>enable</Nullable>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -33,6 +33,8 @@
 		<PackageIcon>logo.png</PackageIcon>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageReleaseNotes>
+			2.0.0-alpha.2329
+			* Update to latest alpha package
 			2.0.0-alpha.2203
 			* True color `ColorPicker`
 			2.0.0-alpha.2189
@@ -150,7 +152,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
 		<PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
-		<PackageReference Include="Terminal.Gui" Version="2.0.0-v2-develop.2203" />
+		<PackageReference Include="Terminal.Gui" Version="2.0.0-v2-develop.2239" />
 		<PackageReference Include="nlog" Version="5.3.3" />
 		<PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.7.7" />
 		<PackageReference Include="System.CodeDom" Version="8.0.0" />

--- a/src/UI/Windows/BigListBox.cs
+++ b/src/UI/Windows/BigListBox.cs
@@ -164,7 +164,7 @@ public class BigListBox<T>
 
         this.callback = Application.AddTimeout(TimeSpan.FromMilliseconds(100), this.Timer);
 
-        this.listView.FocusFirst(TabBehavior.TabStop);
+        this.listView.SetFocus();
     }
 
 
@@ -221,7 +221,7 @@ public class BigListBox<T>
         // backspace or letter/numbers
         if (key == Key.Backspace || char.IsLetterOrDigit(c))
         {
-            this.searchBox?.FocusFirst(TabBehavior.TabStop);
+            this.searchBox?.SetFocus();
             this.searchBox?.NewKeyDownEvent(key);
             key.Handled = true;
         }

--- a/src/UI/Windows/DimEditor.cs
+++ b/src/UI/Windows/DimEditor.cs
@@ -88,7 +88,7 @@ public partial class DimEditor : Dialog, IValueGetterDialog
         // if user types in some text change the focus to the text box to enable entering digits
         if ((obj == Key.Backspace || char.IsDigit(c)) && tbValue.Visible)
         {
-            tbValue?.FocusFirst(TabBehavior.TabStop);
+            tbValue?.SetFocus();
         }
     }
 

--- a/src/UI/Windows/PosEditor.cs
+++ b/src/UI/Windows/PosEditor.cs
@@ -104,7 +104,7 @@ public partial class PosEditor : Dialog, IValueGetterDialog {
         // if user types in some text change the focus to the text box to enable entering digits
         if ((key == Key.Backspace || char.IsDigit(c)) && tbValue.Visible)
         {
-            tbValue?.FocusFirst(TabBehavior.TabStop);
+            tbValue?.SetFocus();
         }            
     }
 


### PR DESCRIPTION
Initial observations

- [ ] Adding a `DateTimeField` implicitly adds a sibling `Popup` view too resulting in 2 views being added.  Likely as a result of https://github.com/gui-cs/Terminal.Gui/issues/3691 and/or https://github.com/gui-cs/Terminal.Gui/pull/3751

- [ ] Keyboard navigation and accept in confirm dialog is broken:
![image](https://github.com/user-attachments/assets/9f3e178f-0b95-4f4b-b750-9210c51a1d2e)
_Pressing Enter does nothing, neither does space or tab.  Only clicking buttons triggers_